### PR TITLE
fix: add gracefull shutdown when clicking stop button for proxy server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -2036,7 +2036,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3007,6 +3007,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3053,11 +3071,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3079,6 +3114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,6 +3136,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3115,10 +3162,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3139,6 +3198,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3220,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3175,6 +3246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3191,6 +3268,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -2036,7 +2036,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3007,24 +3007,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3071,28 +3053,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3114,12 +3079,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3136,12 +3095,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3162,22 +3115,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3198,12 +3139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,12 +3155,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3246,12 +3175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,12 +3191,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/src/bin/ui.rs
+++ b/src/bin/ui.rs
@@ -95,10 +95,16 @@ enum Cmd {
     PollStats,
     /// Probe a single SNI against the given google_ip. Result is written
     /// into UiState::sni_probe keyed by the SNI string.
-    TestSni { google_ip: String, sni: String },
+    TestSni {
+        google_ip: String,
+        sni: String,
+    },
     /// Probe a batch of SNI names. Results appear in UiState::sni_probe one
     /// by one as each probe finishes.
-    TestAllSni { google_ip: String, snis: Vec<String> },
+    TestAllSni {
+        google_ip: String,
+        snis: Vec<String>,
+    },
 }
 
 struct App {
@@ -213,7 +219,10 @@ fn sni_pool_for_form(user: Option<&[String]>, front_domain: &str) -> Vec<SniRow>
     if !user_clean.is_empty() {
         return user_clean
             .into_iter()
-            .map(|name| SniRow { name, enabled: true })
+            .map(|name| SniRow {
+                name,
+                enabled: true,
+            })
             .collect();
     }
     // Default: primary + the other Google-edge subdomains, primary first,
@@ -223,11 +232,17 @@ fn sni_pool_for_form(user: Option<&[String]>, front_domain: &str) -> Vec<SniRow>
     let mut out = Vec::new();
     if !primary.is_empty() {
         seen.insert(primary.clone());
-        out.push(SniRow { name: primary, enabled: true });
+        out.push(SniRow {
+            name: primary,
+            enabled: true,
+        });
     }
     for s in DEFAULT_GOOGLE_SNI_POOL {
         if seen.insert(s.to_string()) {
-            out.push(SniRow { name: (*s).to_string(), enabled: true });
+            out.push(SniRow {
+                name: (*s).to_string(),
+                enabled: true,
+            });
         }
     }
     out
@@ -281,7 +296,11 @@ impl FormState {
             enable_batching: false,
             upstream_socks5: {
                 let v = self.upstream_socks5.trim();
-                if v.is_empty() { None } else { Some(v.to_string()) }
+                if v.is_empty() {
+                    None
+                } else {
+                    Some(v.to_string())
+                }
             },
             parallel_relay: self.parallel_relay,
             sni_hosts: {
@@ -296,7 +315,11 @@ impl FormState {
                 // If the user's pool is empty/all-off we still save as None so
                 // the backend falls back to sensible defaults instead of dying
                 // on an empty pool.
-                if active.is_empty() { None } else { Some(active) }
+                if active.is_empty() {
+                    None
+                } else {
+                    Some(active)
+                }
             },
         })
     }
@@ -307,8 +330,7 @@ fn save_config(cfg: &Config) -> Result<PathBuf, String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    let json = serde_json::to_string_pretty(&ConfigWire::from(cfg))
-        .map_err(|e| e.to_string())?;
+    let json = serde_json::to_string_pretty(&ConfigWire::from(cfg)).map_err(|e| e.to_string())?;
     std::fs::write(&path, json).map_err(|e| e.to_string())?;
     Ok(path)
 }
@@ -368,7 +390,10 @@ impl<'a> From<&'a Config> for ConfigWire<'a> {
             hosts: &c.hosts,
             upstream_socks5: c.upstream_socks5.as_deref(),
             parallel_relay: c.parallel_relay,
-            sni_hosts: c.sni_hosts.as_ref().map(|v| v.iter().map(String::as_str).collect()),
+            sni_hosts: c
+                .sni_hosts
+                .as_ref()
+                .map(|v| v.iter().map(String::as_str).collect()),
         }
     }
 }
@@ -766,14 +791,13 @@ impl App {
                             });
                         }
                     }
-                    if ui.button("Keep working only").on_hover_text(
-                        "Uncheck every SNI that didn't pass the last probe."
-                    ).clicked() {
+                    if ui
+                        .button("Keep working only")
+                        .on_hover_text("Uncheck every SNI that didn't pass the last probe.")
+                        .clicked()
+                    {
                         for row in &mut self.form.sni_pool {
-                            let ok = matches!(
-                                probe_map.get(&row.name),
-                                Some(SniProbeState::Ok(_))
-                            );
+                            let ok = matches!(probe_map.get(&row.name), Some(SniProbeState::Ok(_)));
                             row.enabled = ok;
                         }
                     }
@@ -785,13 +809,20 @@ impl App {
                     if ui.button("Clear status").clicked() {
                         self.shared.state.lock().unwrap().sni_probe.clear();
                     }
-                    if ui.button("Reset to defaults").on_hover_text(
-                        "Replace the list with the built-in Google SNI pool. Custom entries \
-                         are dropped."
-                    ).clicked() {
+                    if ui
+                        .button("Reset to defaults")
+                        .on_hover_text(
+                            "Replace the list with the built-in Google SNI pool. Custom entries \
+                         are dropped.",
+                        )
+                        .clicked()
+                    {
                         self.form.sni_pool = DEFAULT_GOOGLE_SNI_POOL
                             .iter()
-                            .map(|s| SniRow { name: (*s).to_string(), enabled: true })
+                            .map(|s| SniRow {
+                                name: (*s).to_string(),
+                                enabled: true,
+                            })
                             .collect();
                         self.shared.state.lock().unwrap().sni_probe.clear();
                     }
@@ -804,51 +835,55 @@ impl App {
                 let mut test_name: Option<String> = None;
                 const STATUS_W: f32 = 150.0;
                 const NAME_W: f32 = 230.0;
-                egui::ScrollArea::vertical().max_height(280.0).show(ui, |ui| {
-                    for (i, row) in self.form.sni_pool.iter_mut().enumerate() {
-                        ui.horizontal(|ui| {
-                            ui.checkbox(&mut row.enabled, "");
-                            ui.add(
-                                egui::TextEdit::singleline(&mut row.name)
-                                    .desired_width(NAME_W)
-                                    .font(egui::TextStyle::Monospace),
-                            );
-                            let status_txt = match probe_map.get(&row.name) {
-                                Some(SniProbeState::Ok(ms)) => {
-                                    egui::RichText::new(format!("ok  {} ms", ms))
-                                        .color(egui::Color32::from_rgb(80, 180, 100))
-                                        .monospace()
-                                }
-                                Some(SniProbeState::Failed(e)) => {
-                                    let short = if e.len() > 22 { &e[..22] } else { e };
-                                    egui::RichText::new(format!("fail {}", short))
-                                        .color(egui::Color32::from_rgb(220, 110, 110))
-                                        .monospace()
-                                }
-                                Some(SniProbeState::InFlight) => {
-                                    egui::RichText::new("testing…")
+                egui::ScrollArea::vertical()
+                    .max_height(280.0)
+                    .show(ui, |ui| {
+                        for (i, row) in self.form.sni_pool.iter_mut().enumerate() {
+                            ui.horizontal(|ui| {
+                                ui.checkbox(&mut row.enabled, "");
+                                ui.add(
+                                    egui::TextEdit::singleline(&mut row.name)
+                                        .desired_width(NAME_W)
+                                        .font(egui::TextStyle::Monospace),
+                                );
+                                let status_txt = match probe_map.get(&row.name) {
+                                    Some(SniProbeState::Ok(ms)) => {
+                                        egui::RichText::new(format!("ok  {} ms", ms))
+                                            .color(egui::Color32::from_rgb(80, 180, 100))
+                                            .monospace()
+                                    }
+                                    Some(SniProbeState::Failed(e)) => {
+                                        let short = if e.len() > 22 { &e[..22] } else { e };
+                                        egui::RichText::new(format!("fail {}", short))
+                                            .color(egui::Color32::from_rgb(220, 110, 110))
+                                            .monospace()
+                                    }
+                                    Some(SniProbeState::InFlight) => {
+                                        egui::RichText::new("testing…")
+                                            .color(egui::Color32::GRAY)
+                                            .monospace()
+                                    }
+                                    None => egui::RichText::new("untested")
                                         .color(egui::Color32::GRAY)
-                                        .monospace()
+                                        .monospace(),
+                                };
+                                ui.add_sized(
+                                    [STATUS_W, 18.0],
+                                    egui::Label::new(status_txt).truncate(),
+                                );
+                                if ui.small_button("Test").clicked() {
+                                    test_name = Some(row.name.clone());
                                 }
-                                None => {
-                                    egui::RichText::new("untested")
-                                        .color(egui::Color32::GRAY)
-                                        .monospace()
+                                if ui
+                                    .small_button("remove")
+                                    .on_hover_text("Remove this row")
+                                    .clicked()
+                                {
+                                    to_remove = Some(i);
                                 }
-                            };
-                            ui.add_sized([STATUS_W, 18.0], egui::Label::new(status_txt).truncate());
-                            if ui.small_button("Test").clicked() {
-                                test_name = Some(row.name.clone());
-                            }
-                            if ui.small_button("remove")
-                                .on_hover_text("Remove this row")
-                                .clicked()
-                            {
-                                to_remove = Some(i);
-                            }
-                        });
-                    }
-                });
+                            });
+                        }
+                    });
 
                 if let Some(name) = test_name {
                     let name = name.trim().to_string();
@@ -930,12 +965,16 @@ fn fmt_bytes(b: u64) -> String {
 fn background_thread(shared: Arc<Shared>, rx: Receiver<Cmd>) {
     let rt = Runtime::new().expect("failed to create tokio runtime");
 
-    let mut active: Option<(JoinHandle<()>, Arc<AsyncMutex<Option<Arc<DomainFronter>>>>)> = None;
+    let mut active: Option<(
+        JoinHandle<()>,
+        Arc<AsyncMutex<Option<Arc<DomainFronter>>>>,
+        tokio::sync::oneshot::Sender<()>,
+    )> = None;
 
     loop {
         match rx.recv_timeout(Duration::from_millis(250)) {
             Ok(Cmd::PollStats) => {
-                if let Some((_, fronter_slot)) = &active {
+                if let Some((_, fronter_slot, _)) = &active {
                     let slot = fronter_slot.clone();
                     let shared = shared.clone();
                     rt.spawn(async move {
@@ -950,6 +989,7 @@ fn background_thread(shared: Arc<Shared>, rx: Receiver<Cmd>) {
                     });
                 }
             }
+            // In background_thread function, modify the Cmd::Start handler:
             Ok(Cmd::Start(cfg)) => {
                 if active.is_some() {
                     push_log(&shared, "[ui] already running");
@@ -960,6 +1000,8 @@ fn background_thread(shared: Arc<Shared>, rx: Receiver<Cmd>) {
                 let fronter_slot: Arc<AsyncMutex<Option<Arc<DomainFronter>>>> =
                     Arc::new(AsyncMutex::new(None));
                 let fronter_slot2 = fronter_slot.clone();
+
+                let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 
                 let handle = rt.spawn(async move {
                     let base = data_dir::data_dir();
@@ -986,27 +1028,49 @@ fn background_thread(shared: Arc<Shared>, rx: Receiver<Cmd>) {
                         s.running = true;
                         s.started_at = Some(Instant::now());
                     }
-                    push_log(&shared2, &format!(
-                        "[ui] listening HTTP {}:{} SOCKS5 {}:{}",
-                        cfg.listen_host, cfg.listen_port,
-                        cfg.listen_host, cfg.socks5_port.unwrap_or(cfg.listen_port + 1)
-                    ));
-                    let _ = server.run().await;
+                    push_log(
+                        &shared2,
+                        &format!(
+                            "[ui] listening HTTP {}:{} SOCKS5 {}:{}",
+                            cfg.listen_host,
+                            cfg.listen_port,
+                            cfg.listen_host,
+                            cfg.socks5_port.unwrap_or(cfg.listen_port + 1)
+                        ),
+                    );
+
+                    let _ = server.run(shutdown_rx).await;
+
                     shared2.state.lock().unwrap().running = false;
                     push_log(&shared2, "[ui] proxy stopped");
                 });
 
-                active = Some((handle, fronter_slot));
+                active = Some((handle, fronter_slot, shutdown_tx));
             }
+
             Ok(Cmd::Stop) => {
-                if let Some((handle, _)) = active.take() {
-                    handle.abort();
+                if let Some((handle, _, shutdown_tx)) = active.take() {
+                    push_log(&shared, "[ui] stop requested");
+                    let _ = shutdown_tx.send(());
+
+                    // Give the proxy 2 seconds to shut down gracefully
+                    rt.block_on(async {
+                        tokio::select! {
+                            _ = handle => {
+                                push_log(&shared, "[ui] proxy stopped gracefully");
+                            }
+                            _ = tokio::time::sleep(tokio::time::Duration::from_secs(2)) => {
+                                push_log(&shared, "[ui] shutdown timeout, forcing abort");
+                            }
+                        }
+                    });
+
                     shared.state.lock().unwrap().running = false;
                     shared.state.lock().unwrap().started_at = None;
                     shared.state.lock().unwrap().last_stats = None;
-                    push_log(&shared, "[ui] stop requested");
                 }
             }
+
             Ok(Cmd::Test(cfg)) => {
                 let shared2 = shared.clone();
                 push_log(&shared, "[ui] running test...");
@@ -1018,7 +1082,10 @@ fn background_thread(shared: Arc<Shared>, rx: Receiver<Cmd>) {
                     } else {
                         "Test failed — see terminal for details.".into()
                     };
-                    push_log(&shared2, &format!("[ui] test result: {}", if ok { "pass" } else { "fail" }));
+                    push_log(
+                        &shared2,
+                        &format!("[ui] test result: {}", if ok { "pass" } else { "fail" }),
+                    );
                     // Also run ip scan on demand (cheap).
                     let _ = scan_ips::run(&cfg).await;
                 });
@@ -1055,7 +1122,9 @@ fn background_thread(shared: Arc<Shared>, rx: Receiver<Cmd>) {
                     let result = scan_sni::probe_one(&google_ip, &sni).await;
                     let state = match result.latency_ms {
                         Some(ms) => SniProbeState::Ok(ms),
-                        None => SniProbeState::Failed(result.error.unwrap_or_else(|| "failed".into())),
+                        None => {
+                            SniProbeState::Failed(result.error.unwrap_or_else(|| "failed".into()))
+                        }
                     };
                     shared2.state.lock().unwrap().sni_probe.insert(sni, state);
                 });
@@ -1074,7 +1143,9 @@ fn background_thread(shared: Arc<Shared>, rx: Receiver<Cmd>) {
                     for (sni, r) in results {
                         let state = match r.latency_ms {
                             Some(ms) => SniProbeState::Ok(ms),
-                            None => SniProbeState::Failed(r.error.unwrap_or_else(|| "failed".into())),
+                            None => {
+                                SniProbeState::Failed(r.error.unwrap_or_else(|| "failed".into()))
+                            }
                         };
                         st.sni_probe.insert(sni, state);
                     }
@@ -1093,7 +1164,7 @@ fn background_thread(shared: Arc<Shared>, rx: Receiver<Cmd>) {
         }
 
         // Clean up finished task.
-        if let Some((handle, _)) = &active {
+        if let Some((handle, _, _)) = &active {
             if handle.is_finished() {
                 active = None;
                 shared.state.lock().unwrap().running = false;
@@ -1105,7 +1176,9 @@ fn background_thread(shared: Arc<Shared>, rx: Receiver<Cmd>) {
 fn push_log(shared: &Shared, msg: &str) {
     let line = format!(
         "{}  {}",
-        time::OffsetDateTime::now_utc().format(&time::format_description::well_known::Iso8601::DEFAULT).unwrap_or_default(),
+        time::OffsetDateTime::now_utc()
+            .format(&time::format_description::well_known::Iso8601::DEFAULT)
+            .unwrap_or_default(),
         msg
     );
     let mut s = shared.state.lock().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,9 @@ fn parse_args() -> Result<Args, String> {
                 std::process::exit(0);
             }
             "-c" | "--config" => {
-                let v = it.next().ok_or_else(|| "--config needs a path".to_string())?;
+                let v = it
+                    .next()
+                    .ok_or_else(|| "--config needs a path".to_string())?;
                 config_path = Some(PathBuf::from(v));
             }
             "--install-cert" => install_cert = true,
@@ -107,8 +109,7 @@ fn parse_args() -> Result<Args, String> {
 }
 
 fn init_logging(level: &str) {
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(level));
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level));
     let _ = tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_target(false)
@@ -168,22 +169,38 @@ async fn main() -> ExitCode {
     match args.command {
         Command::Test => {
             let ok = test_cmd::run(&config).await;
-            return if ok { ExitCode::SUCCESS } else { ExitCode::FAILURE };
+            return if ok {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            };
         }
         Command::ScanIps => {
             let ok = scan_ips::run(&config).await;
-            return if ok { ExitCode::SUCCESS } else { ExitCode::FAILURE };
+            return if ok {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            };
         }
         Command::TestSni => {
             let ok = mhrv_rs::scan_sni::run(&config).await;
-            return if ok { ExitCode::SUCCESS } else { ExitCode::FAILURE };
+            return if ok {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            };
         }
         Command::Serve => {}
     }
 
     let socks5_port = config.socks5_port.unwrap_or(config.listen_port + 1);
     tracing::warn!("mhrv-rs {} starting (mode: apps_script)", VERSION);
-    tracing::info!("HTTP proxy   : {}:{}", config.listen_host, config.listen_port);
+    tracing::info!(
+        "HTTP proxy   : {}:{}",
+        config.listen_host,
+        config.listen_port
+    );
     tracing::info!("SOCKS5 proxy : {}:{}", config.listen_host, socks5_port);
     tracing::info!(
         "Apps Script relay: SNI={} -> script.google.com (via {})",
@@ -233,7 +250,9 @@ async fn main() -> ExitCode {
         }
     };
 
-    let run = server.run();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+
+    let run = server.run(shutdown_rx);
     tokio::select! {
         r = run => {
             if let Err(e) = r {
@@ -243,6 +262,7 @@ async fn main() -> ExitCode {
         }
         _ = tokio::signal::ctrl_c() => {
             tracing::warn!("Ctrl+C — shutting down.");
+            let _ = shutdown_tx.send(());
         }
     }
     ExitCode::SUCCESS

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -54,7 +54,10 @@ fn matches_sni_rewrite(host: &str) -> bool {
         .any(|s| h == *s || h.ends_with(&format!(".{}", s)))
 }
 
-fn hosts_override<'a>(hosts: &'a std::collections::HashMap<String, String>, host: &str) -> Option<&'a str> {
+fn hosts_override<'a>(
+    hosts: &'a std::collections::HashMap<String, String>,
+    host: &str,
+) -> Option<&'a str> {
     let h = host.to_ascii_lowercase();
     let h = h.trim_end_matches('.');
     if let Some(ip) = hosts.get(h) {
@@ -135,8 +138,10 @@ impl ProxyServer {
     pub fn fronter(&self) -> Arc<DomainFronter> {
         self.fronter.clone()
     }
-
-    pub async fn run(self) -> Result<(), ProxyError> {
+    pub async fn run(
+        self,
+        mut shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+    ) -> Result<(), ProxyError> {
         let http_addr = format!("{}:{}", self.host, self.port);
         let socks_addr = format!("{}:{}", self.host, self.socks5_port);
         let http_listener = TcpListener::bind(&http_addr).await?;
@@ -150,16 +155,13 @@ impl ProxyServer {
             socks_addr
         );
 
-        // Pre-warm the outbound connection pool so the user's first request
-        // doesn't pay a fresh TLS handshake to Google edge. Best-effort;
-        // failures are logged and ignored.
         let warm_fronter = self.fronter.clone();
         tokio::spawn(async move {
             warm_fronter.warm(3).await;
         });
 
         let stats_fronter = self.fronter.clone();
-        tokio::spawn(async move {
+        let stats_task = tokio::spawn(async move {
             let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60));
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             ticker.tick().await;
@@ -175,7 +177,7 @@ impl ProxyServer {
         let http_fronter = self.fronter.clone();
         let http_mitm = self.mitm.clone();
         let http_ctx = self.rewrite_ctx.clone();
-        let http_task = tokio::spawn(async move {
+        let mut http_task = tokio::spawn(async move {
             loop {
                 let (sock, peer) = match http_listener.accept().await {
                     Ok(x) => x,
@@ -199,7 +201,7 @@ impl ProxyServer {
         let socks_fronter = self.fronter.clone();
         let socks_mitm = self.mitm.clone();
         let socks_ctx = self.rewrite_ctx.clone();
-        let socks_task = tokio::spawn(async move {
+        let mut socks_task = tokio::spawn(async move {
             loop {
                 let (sock, peer) = match socks_listener.accept().await {
                     Ok(x) => x,
@@ -220,7 +222,18 @@ impl ProxyServer {
             }
         });
 
-        let _ = tokio::join!(http_task, socks_task);
+        tokio::select! {
+            biased;
+            _ = &mut shutdown_rx => {
+                tracing::info!("Shutdown signal received, stopping listeners");
+                stats_task.abort();
+                http_task.abort();
+                socks_task.abort();
+            }
+            _ = &mut http_task => {}
+            _ = &mut socks_task => {}
+        }
+
         Ok(())
     }
 }
@@ -241,7 +254,8 @@ async fn handle_http_client(
 
     if method.eq_ignore_ascii_case("CONNECT") {
         let (host, port) = parse_host_port(&target);
-        sock.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n").await?;
+        sock.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            .await?;
         sock.flush().await?;
         dispatch_tunnel(sock, host, port, fronter, mitm, rewrite_ctx).await
     } else {
@@ -282,7 +296,8 @@ async fn handle_socks5_client(
     let cmd = req[1];
     if cmd != 0x01 {
         // CONNECT only.
-        sock.write_all(&[0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0]).await?;
+        sock.write_all(&[0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+            .await?;
         return Ok(());
     }
     let atyp = req[3];
@@ -306,7 +321,8 @@ async fn handle_socks5_client(
             addr.to_string()
         }
         _ => {
-            sock.write_all(&[0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0]).await?;
+            sock.write_all(&[0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+                .await?;
             return Ok(());
         }
     };
@@ -317,7 +333,8 @@ async fn handle_socks5_client(
     tracing::info!("SOCKS5 CONNECT -> {}:{}", host, port);
 
     // Success reply with zeroed BND.
-    sock.write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0]).await?;
+    sock.write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+        .await?;
     sock.flush().await?;
 
     dispatch_tunnel(sock, host, port, fronter, mitm, rewrite_ctx).await
@@ -393,7 +410,10 @@ async fn plain_tcp_passthrough(
             Err(e) => {
                 tracing::warn!(
                     "upstream-socks5 {} -> {}:{} failed: {} (falling back to direct)",
-                    proxy, host, port, e
+                    proxy,
+                    host,
+                    port,
+                    e
                 );
                 match tokio::time::timeout(
                     std::time::Duration::from_secs(10),
@@ -443,19 +463,12 @@ async fn plain_tcp_passthrough(
 
 /// Open a TCP stream to `(host, port)` through an upstream SOCKS5 proxy
 /// (no-auth only). Returns the connected stream after SOCKS5 negotiation.
-async fn socks5_connect_via(
-    proxy: &str,
-    host: &str,
-    port: u16,
-) -> std::io::Result<TcpStream> {
+async fn socks5_connect_via(proxy: &str, host: &str, port: u16) -> std::io::Result<TcpStream> {
     use tokio::io::AsyncReadExt;
     use tokio::io::AsyncWriteExt;
-    let mut s = tokio::time::timeout(
-        std::time::Duration::from_secs(5),
-        TcpStream::connect(proxy),
-    )
-    .await
-    .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "connect timeout"))??;
+    let mut s = tokio::time::timeout(std::time::Duration::from_secs(5), TcpStream::connect(proxy))
+        .await
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "connect timeout"))??;
     let _ = s.set_nodelay(true);
 
     // Greeting: VER=5, NMETHODS=1, METHOD=no-auth
@@ -531,15 +544,7 @@ async fn socks5_connect_via(
 fn looks_like_http(first_bytes: &[u8]) -> bool {
     // Cheap sniff: must start with an ASCII HTTP method token followed by a space.
     for m in [
-        "GET ",
-        "POST ",
-        "PUT ",
-        "HEAD ",
-        "DELETE ",
-        "PATCH ",
-        "OPTIONS ",
-        "CONNECT ",
-        "TRACE ",
+        "GET ", "POST ", "PUT ", "HEAD ", "DELETE ", "PATCH ", "OPTIONS ", "CONNECT ", "TRACE ",
     ] {
         if first_bytes.starts_with(m.as_bytes()) {
             return true;
@@ -613,15 +618,7 @@ fn parse_request_head(head: &[u8]) -> Option<(String, String, String, Vec<(Strin
 fn is_valid_http_method(m: &str) -> bool {
     matches!(
         m,
-        "GET"
-            | "POST"
-            | "PUT"
-            | "DELETE"
-            | "HEAD"
-            | "OPTIONS"
-            | "PATCH"
-            | "TRACE"
-            | "CONNECT"
+        "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "OPTIONS" | "PATCH" | "TRACE" | "CONNECT"
     )
 }
 
@@ -704,7 +701,10 @@ async fn do_sni_rewrite_tunnel_from_tcp(
 
     tracing::info!(
         "SNI-rewrite tunnel -> {}:{} via {} (outbound SNI={})",
-        host, port, target_ip, rewrite_ctx.front_domain
+        host,
+        port,
+        target_ip,
+        rewrite_ctx.front_domain
     );
 
     // Accept browser TLS with a cert we sign for `host`.

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -154,7 +154,9 @@ impl ProxyServer {
             "Listening SOCKS5 on {} — xray / Telegram / app-level SOCKS5 clients use this.",
             socks_addr
         );
-
+        // Pre-warm the outbound connection pool so the user's first request
+        // doesn't pay a fresh TLS handshake to Google edge. Best-effort;
+        // failures are logged and ignored.
         let warm_fronter = self.fronter.clone();
         tokio::spawn(async move {
             warm_fronter.warm(3).await;


### PR DESCRIPTION
## Fix graceful shutdown for GUI Stop button

**Problem:**
- Clicking Stop in GUI didn't trigger proper shutdown sequence
- Ports remained locked after stopping (address already in use)
- "Shutdown signal received" log never appeared

**Root Cause:**
GUI was immediately aborting the proxy task right after sending shutdown signal, killing it before it could clean up resources.

**Solution:**
- Send shutdown signal first
- Wait up to 2 seconds for graceful shutdown
- Only force-abort on timeout
- Ports now release immediately when stopping
