### PR TITLE
config: reject zero scan batch size

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -165,6 +165,11 @@ impl Config {
                 ));
             }
         }
+        if self.scan_batch_size == 0 {
+            return Err(ConfigError::Invalid(
+                "scan_batch_size must be greater than 0".into(),
+            ));
+        }
         Ok(())
     }
 
@@ -223,6 +228,18 @@ mod tests {
             "mode": "domain_fronting",
             "auth_key": "SECRET",
             "script_id": "X"
+        }"#;
+        let cfg: Config = serde_json::from_str(s).unwrap();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_zero_scan_batch_size() {
+        let s = r#"{
+            "mode": "apps_script",
+            "auth_key": "SECRET",
+            "script_id": "X",
+            "scan_batch_size": 0
         }"#;
         let cfg: Config = serde_json::from_str(s).unwrap();
         assert!(cfg.validate().is_err());


### PR DESCRIPTION
Validate scan_batch_size at config load time so scan-ips cannot reach candidate_ips.chunks(0) and panic.

Add a focused regression test for scan_batch_size = 0.

-----

Edited and written by GPT.