### PR TITLE
v1.1.2: mipsel-softfloat finally builds (YAML `#` comment-fold bug)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,24 +162,33 @@ jobs:
       # stable channel — no prebuilt std.
       - name: Build CLI (mipsel-softfloat via docker)
         if: matrix.target == 'mipsel-unknown-linux-musl' && matrix.mipsel_softfloat == true
+        # The inner script is single-quoted so the `#` lines stay as
+        # real comments. An earlier version of this step used
+        # `sh -c "... \` (backslash-continuation inside a
+        # double-quoted YAML folded string) which collapsed into one
+        # line — the first `#` then commented out everything after it,
+        # reducing the whole docker payload to `set -eux;` and failing
+        # silently at the post-docker chown. Heredoc-style single
+        # quotes preserve newlines verbatim; no comment collapse.
         run: |
           docker run --rm -v "$PWD":/src -w /src \
             -e RUSTFLAGS='-C target-feature=+soft-float' \
             messense/rust-musl-cross:mipsel-musl \
-            sh -c "set -eux; \
-                   # The image ships with a pre-installed nightly that rustup \
-                   # can't cleanly upgrade — the expected \`clippy-preview/share/doc/clippy/README.md\` \
-                   # is missing, which fails the in-place upgrade \
-                   # (error: failure removing component 'clippy-preview...'). \
-                   # Nuke it first, then install fresh with only the profile \
-                   # bits we actually use. \
-                   rustup toolchain uninstall nightly 2>/dev/null || true; \
-                   rustup toolchain install nightly --profile minimal; \
-                   rustup component add rust-src --toolchain nightly; \
-                   cargo +nightly build --release \
-                     -Z build-std=std,panic_abort \
-                     --target mipsel-unknown-linux-musl \
-                     --bin mhrv-rs"
+            bash -c '
+              set -eux
+              # The image ships a pre-installed nightly that rustup
+              # cannot upgrade in place — `clippy-preview/share/doc/clippy/README.md`
+              # is missing from the pre-bake, and rustup errors with
+              # "failure removing component clippy-preview". Nuke it
+              # first, then install fresh.
+              rustup toolchain uninstall nightly 2>/dev/null || true
+              rustup toolchain install nightly --profile minimal
+              rustup component add rust-src --toolchain nightly
+              cargo +nightly build --release \
+                -Z build-std=std,panic_abort \
+                --target mipsel-unknown-linux-musl \
+                --bin mhrv-rs
+            '
           sudo chown -R "$(id -u):$(id -g)" target
 
       # UI build: we try to build the UI binary on every platform. If it fails

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "mhrv-rs"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mhrv-rs"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "Rust port of MasterHttpRelayVPN -- DPI bypass via Google Apps Script relay with domain fronting"
 license = "MIT"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.therealaleph.mhrv"
         minSdk = 24 // Android 7.0 — covers 99%+ of live devices.
         targetSdk = 34
-        versionCode = 111
-        versionName = "1.1.1"
+        versionCode = 112
+        versionName = "1.1.2"
 
         // Ship all four mainstream Android ABIs:
         //   - arm64-v8a      — 95%+ of real-world Android phones since 2019


### PR DESCRIPTION
## Summary
Patch release. One-line real fix: change the mipsel docker invocation from \`sh -c "... \\\`-continuations with # comments ..."\` to a single-quoted multi-line \`bash -c '...'\` so newlines survive YAML folding. The previous form collapsed into one line and an inline \`#\` commented out the whole toolchain-install + build sequence — the container exited 0 with nothing done, the post-chown failed on the missing \`target/\` directory.

Reopened issue #26 with the explanation — the actual mipsel artifact lands in this tag, not v1.1.1 as I prematurely claimed.

No other code changes.

## Test plan
- [x] `cargo check --lib` on 1.1.2 passes (version bump only touches Cargo.toml/Cargo.lock)
- [ ] CI `mipsel-softfloat` job goes green on tag push
- [ ] Telegram job skips silently (gate variable unset)