### PR TITLE
v1.1.3: portable-atomic polyfill for mipsel-softfloat (real fix this time)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,6 +2199,7 @@ dependencies = [
  "httparse",
  "jni 0.21.1",
  "libc",
+ "portable-atomic",
  "rand 0.8.6",
  "rcgen",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mhrv-rs"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 description = "Rust port of MasterHttpRelayVPN -- DPI bypass via Google Apps Script relay with domain fronting"
 license = "MIT"
@@ -49,6 +49,14 @@ http = "1"
 flate2 = "1"
 directories = "5"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
+# 64-bit atomics on 32-bit MIPS/ARMv5 targets. Rust's std AtomicU64 is
+# only available on targets that expose native 64-bit atomics, which
+# mipsel-unknown-linux-musl does not — `AtomicU64` resolves to "no
+# such name in sync::atomic" and the whole crate fails to build. The
+# `fallback` feature uses a global spinlock when the target can't do
+# 64-bit atomically; on x86_64 / aarch64 / armv7 / etc. it compiles
+# down to the native instructions with no overhead.
+portable-atomic = { version = "1", features = ["fallback"] }
 
 # Optional UI dep: only pulled in when --features ui is set.
 # Both `glow` (OpenGL 2+) and `wgpu` (DX12/Vulkan/Metal) are compiled in;

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.therealaleph.mhrv"
         minSdk = 24 // Android 7.0 — covers 99%+ of live devices.
         targetSdk = 34
-        versionCode = 112
-        versionName = "1.1.2"
+        versionCode = 113
+        versionName = "1.1.3"
 
         // Ship all four mainstream Android ABIs:
         //   - arm64-v8a      — 95%+ of real-world Android phones since 2019

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,5 +1,11 @@
 use std::collections::{HashMap, VecDeque};
-use std::sync::atomic::{AtomicU64, Ordering};
+// AtomicU64 polyfill via portable-atomic — mipsel is MIPS32 with no
+// native 64-bit atomic instructions, so std::sync::atomic::AtomicU64
+// doesn't exist on that target. portable-atomic falls back to a
+// global spinlock on 32-bit MIPS; compiles to native insns on x86_64
+// and aarch64.
+use portable_atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 

--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -10,7 +10,12 @@
 //! TODO: add parallel range-based downloads.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+// AtomicU64 via portable-atomic: native on 64-bit / armv7, spinlock-
+// backed on mipsel (MIPS32 has no 64-bit atomic instructions). API
+// is identical to std::sync::atomic::AtomicU64 so call sites need
+// no other changes.
+use portable_atomic::AtomicU64;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 


### PR DESCRIPTION
## Summary
v1.1.2 finally got the docker/rustup/cargo plumbing right — and exposed the actual root problem I'd been missing across three retags: **`std::sync::atomic::AtomicU64` doesn't exist on mipsel** because MIPS32 has no native 64-bit atomic instructions.

Fix: swap `std::sync::atomic::AtomicU64` → `portable_atomic::AtomicU64` in the two non-gated call sites (`src/cache.rs` + `src/domain_fronter.rs`). `portable-atomic` with the `fallback` feature polyfills u64 atomics via a spinlock on 32-bit MIPS; on 64-bit / armv7 / everywhere else it compiles down to native instructions with no overhead. API is identical, so nothing else changes.

`android_jni.rs` also uses AtomicU64 but is `#![cfg(target_os = "android")]` so mipsel-linux-musl never compiles it.

## Test plan
- [x] `cargo test --lib` on 1.1.3 — 54 passing
- [x] `cargo build --bin mhrv-rs` — clean
- [ ] CI mipsel-softfloat green (this is the moment of truth)
- [ ] 12 assets in release (the original 11 + mipsel)