### PR TITLE
domain_fronter: reject malformed chunked relay responses

### DIFF
--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -1072,10 +1072,16 @@ where
             let n = timeout(Duration::from_secs(20), stream.read(&mut tmp)).await
                 .map_err(|_| FronterError::Timeout)??;
             if n == 0 {
-                out.extend_from_slice(&buf[..buf.len().min(size)]);
-                return Ok(out);
+                return Err(FronterError::BadResponse(
+                    "connection closed mid-chunked response".into(),
+                ));
             }
             buf.extend_from_slice(&tmp[..n]);
+        }
+        if &buf[size..size + 2] != b"\r\n" {
+            return Err(FronterError::BadResponse(
+                "chunk missing trailing CRLF".into(),
+            ));
         }
         out.extend_from_slice(&buf[..size]);
         buf.drain(..size + 2);
@@ -1563,5 +1569,41 @@ mod tests {
         let (status2, _headers2, body2) = read_http_response(&mut server).await.unwrap();
         assert_eq!(status2, 200);
         assert_eq!(body2, b"OK");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn chunked_reader_rejects_truncated_chunk_body() {
+        let (mut client, mut server) = duplex(1024);
+        client
+            .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHel")
+            .await
+            .unwrap();
+        drop(client);
+
+        let err = read_http_response(&mut server).await.unwrap_err();
+        match err {
+            FronterError::BadResponse(msg) => {
+                assert!(msg.contains("mid-chunked"), "unexpected error: {}", msg);
+            }
+            other => panic!("unexpected error: {}", other),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn chunked_reader_rejects_missing_chunk_crlf() {
+        let (mut client, mut server) = duplex(1024);
+        client
+            .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nHelloXX")
+            .await
+            .unwrap();
+        drop(client);
+
+        let err = read_http_response(&mut server).await.unwrap_err();
+        match err {
+            FronterError::BadResponse(msg) => {
+                assert!(msg.contains("trailing CRLF"), "unexpected error: {}", msg);
+            }
+            other => panic!("unexpected error: {}", other),
+        }
     }
 }


### PR DESCRIPTION
read_chunked() previously accepted incomplete chunked bodies when the
upstream stream closed before a full chunk payload and delimiter had been
read. It also drained size + 2 bytes without verifying that the delimiter
after each chunk was "\r\n".

Return FronterError::BadResponse("connection closed mid-chunked response")
when EOF occurs before a complete chunk and delimiter are available, and
return FronterError::BadResponse("chunk missing trailing CRLF") when the
chunk delimiter is invalid.

The test suite now covers both truncated-chunk and missing-CRLF inputs.

-----

Edited and written by GPT.