### PR TITLE
v1.1.5: PR safety merges (#48/#49/#50/#58) + Telegram default = file+link

### DIFF
--- a/.github/scripts/telegram_release_notify.py
+++ b/.github/scripts/telegram_release_notify.py
@@ -159,7 +159,16 @@ def main() -> int:
     ap.add_argument("--apk", required=True)
     ap.add_argument("--version", required=True)
     ap.add_argument("--repo", required=True)
-    ap.add_argument("--changelog", required=True)
+    ap.add_argument("--changelog", required=True,
+                    help="Path to docs/changelog/vX.Y.Z.md; only read when --with-changelog is passed.")
+    # Default: just the APK + short caption (title + SHA-256 + repo URL +
+    # release URL). The per-release Persian/English blockquote reply is
+    # opt-in via `--with-changelog` so routine releases don't flood the
+    # channel with bullet-point bodies. To re-enable for a specific tag:
+    # set the repo variable TELEGRAM_INCLUDE_CHANGELOG=true before pushing
+    # the tag (the workflow converts that into --with-changelog).
+    ap.add_argument("--with-changelog", action="store_true",
+                    help="Include the Persian+English changelog as a reply-threaded message.")
     args = ap.parse_args()
 
     token = os.environ.get("BOT_TOKEN", "")
@@ -179,6 +188,10 @@ def main() -> int:
 
     doc_mid = send_document(token, chat_id, args.apk, caption)
     print(f"sendDocument OK, message_id={doc_mid}")
+
+    if not args.with_changelog:
+        print("Changelog reply disabled (default). Pass --with-changelog to include.")
+        return 0
 
     fa, en = parse_changelog(args.changelog)
     if not fa and not en:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,6 +402,7 @@ jobs:
         env:
           BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          INCLUDE_CHANGELOG: ${{ vars.TELEGRAM_INCLUDE_CHANGELOG }}
         # Python over curl/bash so we don't have to fight curl's -F
         # value-interpretation rules. curl treats `-F "caption=<..."`
         # as "read the caption from file named ..." when the value
@@ -424,8 +425,18 @@ jobs:
             exit 1
           fi
 
+          # --with-changelog is opt-in. Default post is just the APK
+          # plus a short caption with the SHA-256, repo URL, and release
+          # URL — no long body. To include the Persian/English bullets
+          # for a specific tag, set the repo variable
+          # TELEGRAM_INCLUDE_CHANGELOG=true before pushing that tag.
+          INCLUDE_CHANGELOG_FLAG=""
+          if [ "${INCLUDE_CHANGELOG:-}" = "true" ]; then
+            INCLUDE_CHANGELOG_FLAG="--with-changelog"
+          fi
           python3 .github/scripts/telegram_release_notify.py \
             --apk "$APK" \
             --version "$VER" \
             --repo "$GITHUB_REPOSITORY" \
-            --changelog "docs/changelog/v${VER}.md"
+            --changelog "docs/changelog/v${VER}.md" \
+            $INCLUDE_CHANGELOG_FLAG

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "mhrv-rs"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mhrv-rs"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2021"
 description = "Rust port of MasterHttpRelayVPN -- DPI bypass via Google Apps Script relay with domain fronting"
 license = "MIT"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.therealaleph.mhrv"
         minSdk = 24 // Android 7.0 — covers 99%+ of live devices.
         targetSdk = 34
-        versionCode = 114
-        versionName = "1.1.4"
+        versionCode = 115
+        versionName = "1.1.5"
 
         // Ship all four mainstream Android ABIs:
         //   - arm64-v8a      — 95%+ of real-world Android phones since 2019


### PR DESCRIPTION
## Summary
- Merged #48 (Content-Length truncation reject), #49 (chunked truncation + missing-CRLF reject), #50 (SNI-rewrite port 443 only), #58 (Persian README RTL line-break polish).
- Closed #55 (`.cargo/config.toml` + zig-cc shim would break CI; ads/analytics domains miscategorized as YouTube).
- Telegram notify now defaults to file + short caption only. Opt into changelog reply via repo variable `TELEGRAM_INCLUDE_CHANGELOG=true`.

Test suite: 54 → 58 passing.
