### PR TITLE
config: reject HTTP and SOCKS5 port collisions

### DIFF
--- a/src/bin/ui.rs
+++ b/src/bin/ui.rs
@@ -387,6 +387,9 @@ impl FormState {
                     .map_err(|_| "SOCKS5 port must be a number".to_string())?,
             )
         };
+        if socks5_port == Some(listen_port) {
+            return Err("HTTP and SOCKS5 ports must be different".into());
+        }
         let ids: Vec<String> = self
             .script_id
             .split(|c: char| c == '\n' || c == ',')

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,6 +189,11 @@ impl Config {
                 "scan_batch_size must be greater than 0".into(),
             ));
         }
+        if self.socks5_port == Some(self.listen_port) {
+            return Err(ConfigError::Invalid(
+                "listen_port and socks5_port must be different".into(),
+            ));
+        }
         Ok(())
     }
 
@@ -306,6 +311,19 @@ mod tests {
             "auth_key": "SECRET",
             "script_id": "X",
             "scan_batch_size": 0
+        }"#;
+        let cfg: Config = serde_json::from_str(s).unwrap();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_same_http_and_socks5_port() {
+        let s = r#"{
+            "mode": "apps_script",
+            "auth_key": "SECRET",
+            "script_id": "X",
+            "listen_port": 8085,
+            "socks5_port": 8085
         }"#;
         let cfg: Config = serde_json::from_str(s).unwrap();
         assert!(cfg.validate().is_err());


### PR DESCRIPTION
Reject configs that set the HTTP and SOCKS5 listeners to the same port. That configuration fails at runtime when the second listener tries to bind the already-used address.

Validate it both when loading config files and in the UI form path so non-technical users get a direct error before start/save instead of a later bind failure. Add a focused config regression test.