### PR TITLE
Add SNI discovery and DPI validation for Google IPs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,6 +2214,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tun2proxy",
+ "url",
  "webpki-roots 0.26.11",
  "x509-parser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ eframe = { version = "0.28", default-features = false, features = [
     "wgpu",
     "persistence",
 ], optional = true }
+url = "2.5.8"
 
 # Unix-only deps. Must come after `[dependencies]` because starting a new
 # table here otherwise ends the main one — anything below it (incl. eframe)

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use mhrv_rs::cert_installer::{install_ca, is_ca_trusted};
 use mhrv_rs::config::Config;
 use mhrv_rs::mitm::{MitmCertManager, CA_CERT_FILE};
 use mhrv_rs::proxy_server::ProxyServer;
-use mhrv_rs::{scan_ips, test_cmd};
+use mhrv_rs::{scan_ips, scan_sni, test_cmd};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -27,6 +27,7 @@ enum Command {
     Test,
     ScanIps,
     TestSni,
+    ScanSni,
 }
 
 fn print_help() {
@@ -37,6 +38,7 @@ USAGE:
     mhrv-rs [OPTIONS]                  Start the proxy server (default)
     mhrv-rs test [OPTIONS]             Probe the Apps Script relay end-to-end
     mhrv-rs scan-ips [OPTIONS]         Scan Google frontend IPs for reachability + latency
+    mhrv-rs scan-sni         Scan Google SNI name using Google frontend IPs found in 'scan-ips' command
     mhrv-rs test-sni [OPTIONS]         Probe each SNI name in the rotation pool against google_ip
 
 OPTIONS:
@@ -68,6 +70,10 @@ fn parse_args() -> Result<Args, String> {
             }
             "scan-ips" => {
                 command = Command::ScanIps;
+                raw.remove(0);
+            }
+            "scan-sni" => {
+                command = Command::ScanSni;
                 raw.remove(0);
             }
             "test-sni" => {
@@ -190,8 +196,17 @@ async fn main() -> ExitCode {
                 ExitCode::FAILURE
             };
         }
+        Command::ScanSni => {
+            let ok = scan_sni::discover_snis_from_google_ips(&config).await;
+            return if ok {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::FAILURE
+            };
+        }
+
         Command::TestSni => {
-            let ok = mhrv_rs::scan_sni::run(&config).await;
+            let ok = scan_sni::run(&config).await;
             return if ok {
                 ExitCode::SUCCESS
             } else {

--- a/src/scan_ips.rs
+++ b/src/scan_ips.rs
@@ -44,16 +44,118 @@ const CANDIDATE_IPS: &[&str] = &[
     "142.250.64.206",
     "142.250.72.110",
 ];
-
-const FAMOUS_GOOGLE_DOMAINS: &[&str] = &[
+pub const FAMOUS_GOOGLE_DOMAINS: &[&str] = &[
+    // Core services
     "google.com",
     "www.google.com",
     "youtube.com",
     "www.youtube.com",
     "gmail.com",
+    "www.gmail.com",
     "drive.google.com",
     "docs.google.com",
+    "sheets.google.com",
+    "slides.google.com",
     "maps.google.com",
+    "www.maps.google.com",
+    // Search & Discovery
+    "search.google.com",
+    "images.google.com",
+    "www.images.google.com",
+    "news.google.com",
+    "www.news.google.com",
+    "scholar.google.com",
+    "www.scholar.google.com",
+    "books.google.com",
+    "translate.google.com",
+    "www.translate.google.com",
+    // Communication
+    "mail.google.com",
+    "chat.google.com",
+    "meet.google.com",
+    "hangouts.google.com",
+    "voice.google.com",
+    "allo.google.com",
+    // Media & Entertainment
+    "play.google.com",
+    "music.google.com",
+    "movies.google.com",
+    "video.google.com",
+    "videos.google.com",
+    "photos.google.com",
+    "picasa.google.com",
+    "picasaweb.google.com",
+    // Productivity
+    "calendar.google.com",
+    "keep.google.com",
+    "contacts.google.com",
+    "tasks.google.com",
+    "forms.google.com",
+    "sites.google.com",
+    "www.sites.google.com",
+    // Account & Settings
+    "accounts.google.com",
+    "myaccount.google.com",
+    "myactivity.google.com",
+    "passwords.google.com",
+    "adssettings.google.com",
+    // Business & Ads
+    "ads.google.com",
+    "adwords.google.com",
+    "www.adwords.google.com",
+    "adsense.google.com",
+    "analytics.google.com",
+    "business.google.com",
+    "mybusiness.google.com",
+    "merchants.google.com",
+    // Developer & Cloud
+    "console.cloud.google.com",
+    "cloud.google.com",
+    "firebase.google.com",
+    "console.firebase.google.com",
+    "developers.google.com",
+    "console.developers.google.com",
+    "apis.google.com",
+    "fonts.google.com",
+    // Mobile & Apps
+    "android.google.com",
+    "chrome.google.com",
+    "chromebook.google.com",
+    // Education & Learning
+    "classroom.google.com",
+    "edu.google.com",
+    // Shopping & Payments
+    "shopping.google.com",
+    "pay.google.com",
+    "payments.google.com",
+    "wallet.google.com",
+    "store.google.com",
+    // Travel & Local
+    "flights.google.com",
+    "hotels.google.com",
+    "travel.google.com",
+    // Other Services
+    "blogger.google.com",
+    "domains.google.com",
+    "trends.google.com",
+    "alerts.google.com",
+    "podcasts.google.com",
+    "fit.google.com",
+    "home.google.com",
+    "assistant.google.com",
+    "gemini.google.com",
+    // Support & Info
+    "support.google.com",
+    "policies.google.com",
+    "privacy.google.com",
+    "about.google.com",
+    "blog.google.com",
+    // Legacy/Regional
+    "plus.google.com",
+    "www.plus.google.com",
+    "orkut.google.com",
+    "reader.google.com",
+    "wave.google.com",
 ];
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(4);
@@ -92,7 +194,7 @@ pub async fn run(config: &Config) -> bool {
         let ip = ip.to_string();
         tasks.push(tokio::spawn(async move {
             let _permit: Option<tokio::sync::SemaphorePermit<'_>> = sem.acquire().await.ok();
-            probe(&ip, &sni, connector,google_ip_validation).await
+            probe(&ip, &sni, connector, google_ip_validation).await
         }));
     }
 
@@ -134,7 +236,7 @@ pub async fn run(config: &Config) -> bool {
     }
 }
 
-async fn fetch_google_ips(config: &Config) -> Vec<String> {
+pub async fn fetch_google_ips(config: &Config) -> Vec<String> {
     if !config.fetch_ips_from_api {
         tracing::info!("fetch_ips_from_api disabled, using static fallback");
         return CANDIDATE_IPS.iter().map(|s| s.to_string()).collect();
@@ -144,7 +246,7 @@ async fn fetch_google_ips(config: &Config) -> Vec<String> {
         &config.front_domain,
         config.max_ips_to_scan,
         config.scan_batch_size,
-        config.google_ip_validation
+        config.google_ip_validation,
     )
     .await
     {
@@ -170,7 +272,7 @@ async fn fetch_and_validate_google_ips(
     sni: &str,
     max_ips: usize,
     batch_size: usize,
-     google_ip_validation: bool
+    google_ip_validation: bool,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let famous_ips = resolve_famous_domains().await;
     tracing::info!(
@@ -224,21 +326,32 @@ async fn fetch_and_validate_google_ips(
     if candidate_ips.is_empty() {
         return Err("No valid IPs extracted from CIDRs".into());
     }
-
+    let total_batches = (candidate_ips.len() + batch_size - 1) / batch_size;
     tracing::info!(
-        "Selected {} IPs to test (from {} total), testing in batches...",
+        "Selected {} IPs to test (from {} total), testing in {} batches...",
         candidate_ips.len(),
-        priority_ips_len + other_ips_len
+        priority_ips_len + other_ips_len,
+        total_batches
     );
 
     let mut working_ips = Vec::new();
+    let mut total_tested = 0;
 
     for (i, chunk) in candidate_ips.chunks(batch_size).enumerate() {
-        tracing::debug!("Testing batch {} ({} IPs)...", i + 1, chunk.len());
-        let batch_working = validate_ips(chunk, sni,google_ip_validation).await;
-        working_ips.extend(batch_working);
-    }
+        let batch_working = validate_ips(chunk, sni, google_ip_validation).await;
+        working_ips.extend(batch_working.clone());
+        total_tested += chunk.len();
 
+        tracing::info!(
+            "Batch {}/{}: tested {} IPs, found {} working (total: {}/{})",
+            i + 1,
+            total_batches,
+            chunk.len(),
+            batch_working.len(),
+            total_tested,
+            candidate_ips.len()
+        );
+    }
     tracing::info!(
         "Found {} working IPs from {} tested",
         working_ips.len(),
@@ -415,7 +528,11 @@ fn cidr_to_ips(cidr: &str) -> Vec<String> {
         return Vec::new();
     }
     let host_bits = 32 - prefix_len;
-    let num_hosts: u32 = if host_bits >= 32 { u32::MAX } else { 1u32 << host_bits };
+    let num_hosts: u32 = if host_bits >= 32 {
+        u32::MAX
+    } else {
+        1u32 << host_bits
+    };
 
     let limit = num_hosts.min(256);
     if limit < 2 {
@@ -621,7 +738,7 @@ async fn probe(
             }
 
             let lower = response.to_lowercase();
-            let mut  is_google = true;
+            let mut is_google = true;
             if google_ip_validation {
                 is_google = lower.contains("server: gws")
                     || lower.contains("x-google-")

--- a/src/scan_sni.rs
+++ b/src/scan_sni.rs
@@ -11,8 +11,11 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use rustls::RootCertStore;
+use serde::Deserialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
+use tokio::time::timeout;
 use tokio_rustls::rustls::client::danger::{
     HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
 };
@@ -21,6 +24,7 @@ use tokio_rustls::rustls::{ClientConfig, DigitallySignedStruct, SignatureScheme}
 use tokio_rustls::TlsConnector;
 
 use crate::config::Config;
+use crate::scan_ips::{fetch_google_ips, FAMOUS_GOOGLE_DOMAINS};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const CONCURRENCY: usize = 8;
@@ -69,7 +73,10 @@ pub async fn probe_all(google_ip: &str, snis: Vec<String>) -> Vec<(String, Probe
         let ip = google_ip.to_string();
         tasks.push(tokio::spawn(async move {
             let _permit = sem.acquire().await.ok();
-            (sni_clone.clone(), probe_with(&ip, &sni_clone, connector).await)
+            (
+                sni_clone.clone(),
+                probe_with(&ip, &sni_clone, connector).await,
+            )
         }));
     }
     let mut out = Vec::with_capacity(tasks.len());
@@ -163,30 +170,29 @@ async fn probe_with(google_ip: &str, sni: &str, connector: TlsConnector) -> Prob
         }
     };
 
-    let mut tls = match tokio::time::timeout(PROBE_TIMEOUT, connector.connect(server_name, tcp))
-        .await
-    {
-        Ok(Ok(t)) => t,
-        Ok(Err(e)) => {
-            // DPI that blocks the SNI typically kills the handshake here.
-            let emsg = e.to_string();
-            let reason = if emsg.contains("reset") || emsg.contains("peer") {
-                "handshake RST (SNI may be blocked)".into()
-            } else {
-                format!("tls: {}", emsg)
-            };
-            return ProbeResult {
-                latency_ms: None,
-                error: Some(reason),
-            };
-        }
-        Err(_) => {
-            return ProbeResult {
-                latency_ms: None,
-                error: Some("tls handshake timeout".into()),
-            };
-        }
-    };
+    let mut tls =
+        match tokio::time::timeout(PROBE_TIMEOUT, connector.connect(server_name, tcp)).await {
+            Ok(Ok(t)) => t,
+            Ok(Err(e)) => {
+                // DPI that blocks the SNI typically kills the handshake here.
+                let emsg = e.to_string();
+                let reason = if emsg.contains("reset") || emsg.contains("peer") {
+                    "handshake RST (SNI may be blocked)".into()
+                } else {
+                    format!("tls: {}", emsg)
+                };
+                return ProbeResult {
+                    latency_ms: None,
+                    error: Some(reason),
+                };
+            }
+            Err(_) => {
+                return ProbeResult {
+                    latency_ms: None,
+                    error: Some("tls handshake timeout".into()),
+                };
+            }
+        };
 
     // Handshake completed — SNI passed. Do a tiny HEAD to confirm the other
     // side actually speaks HTTP (catches weird misroutes).
@@ -271,6 +277,235 @@ fn truncate_reason(s: &str, max: usize) -> String {
         let cleaned: String = s.chars().take(max).filter(|c| !c.is_control()).collect();
         cleaned
     }
+}
+
+#[derive(Deserialize)]
+struct DnsResponse {
+    #[serde(rename = "Answer")]
+    answer: Option<Vec<DnsAnswer>>,
+}
+
+#[derive(Deserialize)]
+struct DnsAnswer {
+    data: String,
+}
+pub async fn discover_snis_from_google_ips(config: &Config) -> bool {
+    let ips = fetch_google_ips(config).await;
+    println!(
+        "Discovering SNIs for {} Google IPs via dns.google...",
+        ips.len()
+    );
+    println!();
+
+    let sem = Arc::new(tokio::sync::Semaphore::new(20));
+    let mut tasks = Vec::new();
+
+    for ip in ips {
+        let sem = sem.clone();
+
+        tasks.push(tokio::spawn(async move {
+            let _permit = sem.acquire().await.ok();
+
+            let octets: Vec<&str> = ip.split('.').collect();
+            if octets.len() != 4 {
+                return Vec::new();
+            }
+
+            let ptr_name = format!(
+                "{}.{}.{}.{}.in-addr.arpa",
+                octets[3], octets[2], octets[1], octets[0]
+            );
+
+            let url = format!("https://dns.google/resolve?name={}&type=PTR", ptr_name);
+
+            match fetch_dns_info(&url).await {
+                Ok(body) => {
+                    if let Ok(dns_resp) = serde_json::from_str::<DnsResponse>(&body) {
+                        if let Some(answers) = dns_resp.answer {
+                            return answers
+                                .into_iter()
+                                .map(|a| a.data.trim_end_matches('.').to_lowercase())
+                                .filter(|d| {
+                                    d.contains("1e100.net")
+                                        || d.contains("google")
+                                        || d.contains("goog")
+                                        || d.contains("youtube")
+                                        || FAMOUS_GOOGLE_DOMAINS.iter().any(|famous| {
+                                            let base = famous
+                                                .trim_start_matches("www.")
+                                                .trim_end_matches(".com");
+                                            d.contains(base)
+                                        })
+                                })
+                                .collect::<Vec<_>>();
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("PTR lookup failed for {}: {}", ip, e);
+                }
+            }
+            Vec::new()
+        }));
+    }
+
+    let mut all_domains = std::collections::HashSet::new();
+    for task in tasks {
+        if let Ok(domains) = task.await {
+            all_domains.extend(domains);
+        }
+    }
+
+    let discovered: Vec<String> = all_domains.into_iter().collect();
+
+    if discovered.is_empty() {
+        println!("No SNI domains discovered.");
+        println!();
+        return false;
+    }
+
+    println!(
+        "Validating {} SNIs against DPI (IP: {})...",
+        discovered.len(),
+        config.google_ip
+    );
+    println!();
+
+    let sem = Arc::new(tokio::sync::Semaphore::new(config.scan_batch_size));
+    let mut validation_tasks = Vec::new();
+
+    for sni in discovered {
+        let test_ip_owned = config.google_ip.to_string();
+        let sem = sem.clone();
+
+        validation_tasks.push(tokio::spawn(async move {
+            let _permit = sem.acquire().await.ok();
+            if validate_sni_against_dpi(&sni, &test_ip_owned).await {
+                Some(sni)
+            } else {
+                None
+            }
+        }));
+    }
+
+    let mut validation_ok: Vec<String> = Vec::new();
+
+    for task in validation_tasks {
+        if let Ok(Some(sni)) = task.await {
+            validation_ok.push(sni);
+        }
+    }
+
+    if validation_ok.is_empty() {
+        println!("No SNI domains passed DPI validation.");
+        println!();
+        false
+    } else {
+        validation_ok.sort();
+        println!("SNIs that passed DPI validation:");
+        println!();
+        for sni in validation_ok {
+            println!("  {}", sni);
+        }
+        println!();
+        true
+    }
+}
+
+async fn validate_sni_against_dpi(sni: &str, test_ip: &str) -> bool {
+    let addr = format!("{}:443", test_ip);
+
+    let tcp_stream = match timeout(Duration::from_secs(5), TcpStream::connect(&addr)).await {
+        Ok(Ok(stream)) => stream,
+        _ => return false,
+    };
+
+    let mut root_store = RootCertStore::empty();
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    let config = ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+
+    let connector = TlsConnector::from(Arc::new(config));
+
+    let sni_owned = sni.to_string();
+    let domain = match ServerName::try_from(sni_owned.as_str()) {
+        Ok(d) => d.to_owned(),
+        Err(_) => return false,
+    };
+
+    match timeout(
+        Duration::from_secs(5),
+        connector.connect(domain, tcp_stream),
+    )
+    .await
+    {
+        Ok(Ok(_)) => true,
+        _ => false,
+    }
+}
+
+pub async fn fetch_dns_info(url_addr: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let parsed = url::Url::parse(url_addr)?;
+    let host = parsed.host_str().ok_or("No host in URL")?;
+    let port = parsed.port().unwrap_or(443);
+    let path = if parsed.path().is_empty() {
+        "/"
+    } else {
+        parsed.path()
+    };
+    let query = parsed
+        .query()
+        .map(|q| format!("?{}", q))
+        .unwrap_or_default();
+
+    let stream = tokio::time::timeout(
+        Duration::from_secs(10),
+        TcpStream::connect(format!("{}:{}", host, port)),
+    )
+    .await??;
+
+    let tls_cfg = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerify))
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(tls_cfg));
+    let server_name = ServerName::try_from(host.to_string())?;
+
+    let mut tls_stream = tokio::time::timeout(
+        Duration::from_secs(10),
+        connector.connect(server_name, stream),
+    )
+    .await??;
+
+    let request = format!(
+        "GET {}{} HTTP/1.1\r\nHost: {}\r\nUser-Agent: Mozilla/5.0\r\nConnection: close\r\n\r\n",
+        path, query, host
+    );
+    tls_stream.write_all(request.as_bytes()).await?;
+    tls_stream.flush().await?;
+
+    let mut response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(15), async {
+        let mut buf = [0u8; 4096];
+        loop {
+            match tls_stream.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => response.extend_from_slice(&buf[..n]),
+                Err(_) => break,
+            }
+        }
+    })
+    .await?;
+
+    let response_str = String::from_utf8_lossy(&response);
+    let body = response_str
+        .split("\r\n\r\n")
+        .nth(1)
+        .ok_or("No HTTP body found")?;
+
+    Ok(body.to_string())
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Implements automated SNI discovery from Google IP ranges with DPI bypass validation.

## Changes:

- Added PTR record lookup via dns.google to discover SNI domains from Google IPs
- Implemented DPI validation by testing TLS handshakes against live Google infrastructure
- Added progress tracking for batch IP testing with detailed statistics
- Enhanced SNI filtering logic to catch [1e100.net](http://1e100.net/) domains and Google-related substrings
- Expanded FAMOUS_GOOGLE_DOMAINS list with frontend-focused services
- The discovery process fetches Google IP ranges, performs reverse DNS lookups to find associated domains, filters for Google-related SNIs, then validates each against a test IP to ensure they bypass DPI blocking.

as in #9 i implemented ip lookup we can extend dynamic scanning which there is no guarantee it  be helpful and return valid and working sni's but it may worth having.

**NOTE:** this #47 suggested many new sni addresses which the whole purpose of this scanner is to find some of this without using non google related services as Iran users don't have access to them. it is obvious that cert.sh can return many better result