### PR TITLE
fix(android): keep empty ONLY split lists self-excluded

### DIFF
--- a/android/app/src/main/java/com/therealaleph/mhrv/MhrvVpnService.kt
+++ b/android/app/src/main/java/com/therealaleph/mhrv/MhrvVpnService.kt
@@ -191,11 +191,21 @@ class MhrvVpnService : VpnService() {
                         builder.addDisallowedApplication(packageName)
                     } catch (_: Throwable) {}
                 } else {
+                    var allowed = 0
                     for (pkg in cfg.splitApps) {
                         if (pkg == packageName) continue  // can't tunnel ourselves
-                        try { builder.addAllowedApplication(pkg) } catch (e: Throwable) {
+                        try {
+                            builder.addAllowedApplication(pkg)
+                            allowed++
+                        } catch (e: Throwable) {
                             Log.w(TAG, "addAllowedApplication($pkg) failed: ${e.message}")
                         }
+                    }
+                    if (allowed == 0) {
+                        Log.w(TAG, "ONLY mode had no usable apps — falling back to ALL")
+                        try {
+                            builder.addDisallowedApplication(packageName)
+                        } catch (_: Throwable) {}
                     }
                 }
             }


### PR DESCRIPTION
When ONLY mode contains only this app or stale packages, no allowed application is successfully added. Android then treats the VPN as applying to every app, which can route more traffic than requested and can also include our own proxy traffic in the TUN path. Count successful addAllowedApplication calls and fall back to the existing ALL-mode self-exclusion behavior when none are usable.