### PR TITLE
feat: native udpgw protocol + Cloud Run vs VPS docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,8 +3892,7 @@ dependencies = [
 [[package]]
 name = "tun2proxy"
 version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0576f75fd691ad86cdc4348f29fb8770037ab8140179f1f9f8f6991f7ebd2176"
+source = "git+https://github.com/yyoyoian-pixel/tun2proxy.git?branch=main#d55e6025cc9953948a87e2be471bf8dd15c4a8f8"
 dependencies = [
  "android_logger",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ libc = "0.2"
 # traffic black-holes (symptom: Chrome shows DNS_PROBE_STARTED).
 [target.'cfg(target_os = "android")'.dependencies]
 jni = { version = "0.21", default-features = false }
-tun2proxy = { version = "0.7", default-features = false }
+tun2proxy = { git = "https://github.com/yyoyoian-pixel/tun2proxy.git", branch = "main", default-features = false, features = ["udpgw"] }
 
 [dev-dependencies]
 # Used in mitm tests to sanity-check the cert extensions we emit.

--- a/README.md
+++ b/README.md
@@ -297,13 +297,15 @@ More deployments = more total concurrency = lower per-session latency. Each batc
    - **Solo use** → 1–2 accounts is plenty
    - **Shared with ~3 people** → 3 accounts
    - **Shared with a group** → one account per heavy user
-2. Deploy the [tunnel-node](tunnel-node/) on a VPS. The fastest path is the prebuilt Docker image:
+2. Deploy the [tunnel-node](tunnel-node/) on a **VPS** (recommended) or Cloud Run. The fastest path is the prebuilt Docker image:
    ```bash
    docker run -d --name mhrv-tunnel --restart unless-stopped \
      -p 8080:8080 -e TUNNEL_AUTH_KEY=your-strong-secret \
      ghcr.io/therealaleph/mhrv-tunnel-node:latest
    ```
    Multi-arch (linux/amd64 + linux/arm64), runs as a non-root user, ~32 MB compressed. Pin a version tag (`:1.5.0`) for production. See [tunnel-node/README.md](tunnel-node/README.md) for Cloud Run, docker-compose, and source-build alternatives.
+
+   > **VPS vs Cloud Run**: a VPS gives you full UDP support (needed for udpgw — DNS-over-UDP, QUIC, Telegram calls). Cloud Run works for TCP-only traffic but drops UDP responses. Use a VPS if you need UDP.
 3. Set `"mode": "full"` in your config with all deployment IDs:
 
 ```json
@@ -643,6 +645,8 @@ docker run -d --name mhrv-tunnel --restart unless-stopped \
 ```
 
 `multi-arch` (هم `linux/amd64` و هم `linux/arm64`)، اجرا با کاربر غیر `root`، حدود ۳۲ مگابایت فشرده. برای محیط production نسخهٔ مشخص (`:1.5.0`) را pin کنید. راهنمای کامل (شامل `Cloud Run`، `docker-compose`، و بیلد از سورس) در [`tunnel-node/README.md`](tunnel-node/README.md) هست.
+
+> **`VPS` در مقابل `Cloud Run`**: سرور `VPS` پشتیبانی کامل از `UDP` دارد (برای `udpgw` — `DNS`، `QUIC`، تماس تلگرام). `Cloud Run` فقط `TCP` را پشتیبانی می‌کند و پاسخ‌های `UDP` را دریافت نمی‌کند. اگر به `UDP` نیاز دارید از `VPS` استفاده کنید.
 
 #### چرا تعداد `Deployment ID` مهم است؟
 

--- a/android/app/src/main/java/com/github/shadowsocks/bg/Tun2proxy.kt
+++ b/android/app/src/main/java/com/github/shadowsocks/bg/Tun2proxy.kt
@@ -59,6 +59,7 @@ object Tun2proxy {
         tunMtu: Char,
         verbosity: Int,
         dnsStrategy: Int,
+        udpgwServer: String,
     ): Int
 
     /** Signals the running `run()` to shut down. Idempotent. */

--- a/android/app/src/main/java/com/therealaleph/mhrv/MhrvVpnService.kt
+++ b/android/app/src/main/java/com/therealaleph/mhrv/MhrvVpnService.kt
@@ -249,6 +249,10 @@ class MhrvVpnService : VpnService() {
         //    the sole owner once it's running.
         val detachedFd = parcelFd.detachFd()
         tun2proxyRunning.set(true)
+        // In full mode, enable udpgw so UDP traffic (DNS, QUIC, …) is
+        // forwarded through the tunnel-node's native udpgw handler.
+        // 198.18.0.1:7300 is a magic address the tunnel-node intercepts.
+        val udpgwAddr = if (cfg.mode == Mode.FULL) "198.18.0.1:7300" else ""
         val worker = Thread({
             try {
                 val rc = Tun2proxy.run(
@@ -258,6 +262,7 @@ class MhrvVpnService : VpnService() {
                     MTU.toChar(),
                     /* verbosity = info */ 3,
                     /* dnsStrategy = virtual */ 0,
+                    udpgwAddr,
                 )
                 Log.i(TAG, "tun2proxy exited rc=$rc")
             } catch (t: Throwable) {

--- a/src/android_jni.rs
+++ b/src/android_jni.rs
@@ -482,3 +482,4 @@ pub extern "system" fn Java_com_therealaleph_mhrv_Native_statsJson<'a>(
     }));
     env.new_string(out).map(|s| s.into_raw()).unwrap_or(std::ptr::null_mut())
 }
+

--- a/tunnel-node/README.md
+++ b/tunnel-node/README.md
@@ -19,7 +19,9 @@ The tunnel node manages persistent TCP and UDP sessions. TCP sessions are real T
 
 ## Deployment
 
-### Cloud Run
+> **Cloud Run vs VPS**: Cloud Run works for TCP-only traffic but **does not support UDP responses** — outbound UDP packets are sent but replies never reach the container. If you need UDP forwarding (udpgw for Telegram calls, QUIC, DNS-over-UDP, etc.), deploy on a **VPS** instead. The Docker and direct-binary methods below all work on any VPS with full UDP support.
+
+### Cloud Run (TCP only)
 
 ```bash
 cd tunnel-node
@@ -32,6 +34,8 @@ gcloud run deploy tunnel-node \
   --cpu 1 \
   --max-instances 1
 ```
+
+Cloud Run is the easiest deployment path but UDP-based features (udpgw) will not work. Use a VPS if you need UDP.
 
 ### Docker — prebuilt image (any VPS)
 
@@ -118,6 +122,20 @@ TUNNEL_AUTH_KEY=your-secret PORT=8080 ./target/release/tunnel-node
 ```
 
 ### Health check: `GET /health` → `ok`
+
+## UDP forwarding (udpgw)
+
+The tunnel-node includes a native implementation of the [tun2proxy udpgw](https://github.com/tun2proxy/tun2proxy) wire protocol. When the client opens a tunnel session to the magic address `198.18.0.1:7300`, the tunnel-node creates a virtual session that speaks the udpgw binary protocol instead of raw TCP passthrough. This enables UDP traffic (DNS, QUIC, Telegram VoIP, etc.) to flow through the existing HTTP tunnel.
+
+**Requirements:**
+- **VPS deployment** — Cloud Run does not support inbound UDP responses. Deploy on a VPS (Docker or direct binary) for udpgw to work.
+- **Android client** — the forked tun2proxy with udpgw JNI support passes `--udpgw-server 198.18.0.1:7300` when in full mode. Desktop clients can use any tun2socks/tun2proxy binary with `--udpgw-server`.
+
+**How it works:**
+1. tun2proxy captures a UDP packet and opens a TCP connection to `198.18.0.1:7300` through the SOCKS5 proxy
+2. The TCP connection flows through the tunnel pipeline (mhrv-rs → Apps Script → tunnel-node)
+3. The tunnel-node detects the magic address and creates an in-process udpgw session (no real TCP connection)
+4. UDP datagrams are encapsulated in udpgw frames, sent as real UDP from the VPS, and responses flow back the same path
 
 ## Performance: deployment count and pipeline depth
 

--- a/tunnel-node/src/main.rs
+++ b/tunnel-node/src/main.rs
@@ -22,11 +22,13 @@ use axum::{routing::post, Json, Router};
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::net::tcp::OwnedWriteHalf;
 use tokio::net::{lookup_host, TcpStream, UdpSocket};
 use tokio::sync::{mpsc, Mutex, Notify};
 use tokio::task::JoinSet;
+
+mod udpgw;
 
 /// Structured error code returned when the tunnel-node receives an op it
 /// doesn't recognize. Clients use this (rather than string-matching `e`) to
@@ -95,8 +97,30 @@ const UDP_QUEUE_DROP_LOG_STRIDE: u64 = 100;
 // Session
 // ---------------------------------------------------------------------------
 
+/// Writer half — either a real TCP socket or an in-process duplex channel
+/// (used for virtual sessions like udpgw).
+enum SessionWriter {
+    Tcp(OwnedWriteHalf),
+    Duplex(tokio::io::WriteHalf<tokio::io::DuplexStream>),
+}
+
+impl SessionWriter {
+    async fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        match self {
+            SessionWriter::Tcp(w) => w.write_all(buf).await,
+            SessionWriter::Duplex(w) => w.write_all(buf).await,
+        }
+    }
+    async fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            SessionWriter::Tcp(w) => w.flush().await,
+            SessionWriter::Duplex(w) => w.flush().await,
+        }
+    }
+}
+
 struct SessionInner {
-    writer: Mutex<OwnedWriteHalf>,
+    writer: Mutex<SessionWriter>,
     read_buf: Mutex<Vec<u8>>,
     eof: AtomicBool,
     last_active: Mutex<Instant>,
@@ -110,6 +134,17 @@ struct SessionInner {
 struct ManagedSession {
     inner: Arc<SessionInner>,
     reader_handle: tokio::task::JoinHandle<()>,
+    /// For udpgw sessions, the server task handle (so we can abort on close).
+    udpgw_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl ManagedSession {
+    fn abort_all(&self) {
+        self.reader_handle.abort();
+        if let Some(ref h) = self.udpgw_handle {
+            h.abort();
+        }
+    }
 }
 
 /// UDP equivalent of `SessionInner`. Holds a *connected* `UdpSocket`
@@ -148,7 +183,7 @@ async fn create_session(host: &str, port: u16) -> std::io::Result<ManagedSession
     let (reader, writer) = stream.into_split();
 
     let inner = Arc::new(SessionInner {
-        writer: Mutex::new(writer),
+        writer: Mutex::new(SessionWriter::Tcp(writer)),
         read_buf: Mutex::new(Vec::with_capacity(32768)),
         eof: AtomicBool::new(false),
         last_active: Mutex::new(Instant::now()),
@@ -158,10 +193,10 @@ async fn create_session(host: &str, port: u16) -> std::io::Result<ManagedSession
     let inner_ref = inner.clone();
     let reader_handle = tokio::spawn(reader_task(reader, inner_ref));
 
-    Ok(ManagedSession { inner, reader_handle })
+    Ok(ManagedSession { inner, reader_handle, udpgw_handle: None })
 }
 
-async fn reader_task(mut reader: OwnedReadHalf, session: Arc<SessionInner>) {
+async fn reader_task(mut reader: impl AsyncRead + Unpin, session: Arc<SessionInner>) {
     let mut buf = vec![0u8; 65536];
     loop {
         match reader.read(&mut buf).await {
@@ -966,14 +1001,38 @@ fn validate_host_port(
     Ok((host, port))
 }
 
+/// Create a virtual udpgw session backed by an in-process duplex channel.
+fn create_udpgw_session() -> ManagedSession {
+    let (client_half, server_half) = tokio::io::duplex(65536);
+    let (read_half, write_half) = tokio::io::split(client_half);
+
+    let inner = Arc::new(SessionInner {
+        writer: Mutex::new(SessionWriter::Duplex(write_half)),
+        read_buf: Mutex::new(Vec::with_capacity(32768)),
+        eof: AtomicBool::new(false),
+        last_active: Mutex::new(Instant::now()),
+        notify: Notify::new(),
+    });
+
+    let inner_ref = inner.clone();
+    let reader_handle = tokio::spawn(reader_task(read_half, inner_ref));
+    let udpgw_handle = Some(tokio::spawn(udpgw::udpgw_server_task(server_half)));
+
+    ManagedSession { inner, reader_handle, udpgw_handle }
+}
+
 async fn handle_connect(state: &AppState, host: Option<String>, port: Option<u16>) -> TunnelResponse {
     let (host, port) = match validate_host_port(host, port) {
         Ok(v) => v,
         Err(r) => return r,
     };
-    let session = match create_session(&host, port).await {
-        Ok(s) => s,
-        Err(e) => return TunnelResponse::error(format!("connect failed: {}", e)),
+    let session = if udpgw::is_udpgw_dest(&host, port) {
+        create_udpgw_session()
+    } else {
+        match create_session(&host, port).await {
+            Ok(s) => s,
+            Err(e) => return TunnelResponse::error(format!("connect failed: {}", e)),
+        }
     };
     let sid = uuid::Uuid::new_v4().to_string();
     tracing::info!("session {} -> {}:{}", sid, host, port);
@@ -995,9 +1054,13 @@ async fn handle_connect_data_phase1(
 ) -> Result<(String, Arc<SessionInner>), TunnelResponse> {
     let (host, port) = validate_host_port(host, port)?;
 
-    let session = create_session(&host, port)
-        .await
-        .map_err(|e| TunnelResponse::error(format!("connect failed: {}", e)))?;
+    let session = if udpgw::is_udpgw_dest(&host, port) {
+        create_udpgw_session()
+    } else {
+        create_session(&host, port)
+            .await
+            .map_err(|e| TunnelResponse::error(format!("connect failed: {}", e)))?
+    };
 
     // Any failure below this point must abort the reader task, otherwise
     // the newly-opened upstream TCP connection would leak. Keep the
@@ -1007,7 +1070,7 @@ async fn handle_connect_data_phase1(
             let bytes = match B64.decode(data_b64) {
                 Ok(b) => b,
                 Err(e) => {
-                    session.reader_handle.abort();
+                    session.abort_all();
                     return Err(TunnelResponse::error(format!("bad base64: {}", e)));
                 }
             };
@@ -1015,7 +1078,7 @@ async fn handle_connect_data_phase1(
                 let mut w = session.inner.writer.lock().await;
                 if let Err(e) = w.write_all(&bytes).await {
                     drop(w);
-                    session.reader_handle.abort();
+                    session.abort_all();
                     return Err(TunnelResponse::error(format!("write failed: {}", e)));
                 }
                 let _ = w.flush().await;
@@ -1084,7 +1147,7 @@ async fn handle_connect_data_single(
     let (data, eof) = wait_and_drain(&inner, Duration::from_secs(5)).await;
     if eof {
         if let Some(s) = state.sessions.lock().await.remove(&sid) {
-            s.reader_handle.abort();
+            s.abort_all();
             tracing::info!("session {} closed by remote", sid);
         }
     }
@@ -1128,7 +1191,7 @@ async fn handle_data_single(state: &AppState, sid: Option<String>, data: Option<
     drop(sessions);
     if eof {
         if let Some(s) = state.sessions.lock().await.remove(&sid) {
-            s.reader_handle.abort();
+            s.abort_all();
             tracing::info!("session {} closed by remote", sid);
         }
     }
@@ -1146,7 +1209,7 @@ async fn handle_close(state: &AppState, sid: Option<String>) -> TunnelResponse {
         _ => return TunnelResponse::error("missing sid"),
     };
     if let Some(s) = state.sessions.lock().await.remove(&sid) {
-        s.reader_handle.abort();
+        s.abort_all();
         tracing::info!("session {} closed by client", sid);
     }
     if let Some(s) = state.udp_sessions.lock().await.remove(&sid) {
@@ -1191,10 +1254,6 @@ async fn cleanup_task(
         }
 
         {
-            // UDP sessions get a tighter idle window because UDP flows
-            // are typically short-lived (DNS, STUN, single-RTT QUIC) or
-            // make their own keepalives. 120 s avoids leaking sockets
-            // for one-shot lookups while keeping calls/streams alive.
             let mut map = udp_sessions.lock().await;
             let mut stale = Vec::new();
             for (k, s) in map.iter() {
@@ -1430,7 +1489,7 @@ mod tests {
         let (_reader, writer) = client.into_split();
 
         Arc::new(SessionInner {
-            writer: Mutex::new(writer),
+            writer: Mutex::new(SessionWriter::Tcp(writer)),
             read_buf: Mutex::new(Vec::new()),
             eof: AtomicBool::new(false),
             last_active: Mutex::new(Instant::now()),
@@ -1597,7 +1656,7 @@ mod tests {
         let stream = TcpStream::connect(addr).await.unwrap();
         let (reader, writer) = stream.into_split();
         let inner = Arc::new(SessionInner {
-            writer: Mutex::new(writer),
+            writer: Mutex::new(SessionWriter::Tcp(writer)),
             read_buf: Mutex::new(Vec::new()),
             eof: AtomicBool::new(false),
             last_active: Mutex::new(Instant::now()),

--- a/tunnel-node/src/udpgw.rs
+++ b/tunnel-node/src/udpgw.rs
@@ -1,0 +1,460 @@
+//! Native implementation of the tun2proxy udpgw wire protocol.
+//!
+//! Wire format (all fields big-endian):
+//! ```text
+//! +-----+-------+---------+------+----------+----------+----------+
+//! | LEN | FLAGS | CONN_ID | ATYP | DST.ADDR | DST.PORT |   DATA   |
+//! +-----+-------+---------+------+----------+----------+----------+
+//! |  2  |   1   |    2    |  1   | Variable |    2     | Variable |
+//! +-----+-------+---------+------+----------+----------+----------+
+//! ```
+//!
+//! Flags: KEEPALIVE=0x01, DATA=0x02, ERR=0x20
+//! ATYP: 0x01=IPv4(4B), 0x03=Domain(1B len + name), 0x04=IPv6(16B)
+
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+use tokio::net::UdpSocket;
+
+/// Magic address that the client connects to via the tunnel protocol.
+/// `198.18.0.0/15` is reserved for benchmarking (RFC 2544) and will
+/// never be a real destination.
+pub const UDPGW_MAGIC_IP: [u8; 4] = [198, 18, 0, 1];
+pub const UDPGW_MAGIC_PORT: u16 = 7300;
+
+const FLAG_KEEPALIVE: u8 = 0x01;
+const FLAG_DATA: u8 = 0x02;
+const FLAG_ERR: u8 = 0x20;
+
+const ATYP_IPV4: u8 = 0x01;
+const ATYP_DOMAIN: u8 = 0x03;
+const ATYP_IPV6: u8 = 0x04;
+
+/// Timeout for a single UDP round-trip (send + recv).
+const UDP_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Maximum UDP payload we'll handle.
+const UDP_MTU: usize = 10240;
+
+// -------------------------------------------------------------------------
+// Frame types
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+enum DstAddr {
+    V4(Ipv4Addr, u16),
+    V6(Ipv6Addr, u16),
+    Domain(String, u16),
+}
+
+impl DstAddr {
+    fn to_socket_addr(&self) -> std::io::Result<SocketAddr> {
+        match self {
+            DstAddr::V4(ip, port) => Ok(SocketAddr::V4(SocketAddrV4::new(*ip, *port))),
+            DstAddr::V6(ip, port) => Ok(SocketAddr::V6(SocketAddrV6::new(*ip, *port, 0, 0))),
+            DstAddr::Domain(name, port) => {
+                use std::net::ToSocketAddrs;
+                (name.as_str(), *port)
+                    .to_socket_addrs()?
+                    .next()
+                    .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::AddrNotAvailable, "DNS resolution failed"))
+            }
+        }
+    }
+
+    /// Serialise into SOCKS5 address format: ATYP + addr + port.
+    fn write_to(&self, buf: &mut Vec<u8>) {
+        match self {
+            DstAddr::V4(ip, port) => {
+                buf.push(ATYP_IPV4);
+                buf.extend_from_slice(&ip.octets());
+                buf.extend_from_slice(&port.to_be_bytes());
+            }
+            DstAddr::V6(ip, port) => {
+                buf.push(ATYP_IPV6);
+                buf.extend_from_slice(&ip.octets());
+                buf.extend_from_slice(&port.to_be_bytes());
+            }
+            DstAddr::Domain(name, port) => {
+                buf.push(ATYP_DOMAIN);
+                buf.push(name.len() as u8);
+                buf.extend_from_slice(name.as_bytes());
+                buf.extend_from_slice(&port.to_be_bytes());
+            }
+        }
+    }
+
+    fn serialised_len(&self) -> usize {
+        match self {
+            DstAddr::V4(..) => 1 + 4 + 2,       // ATYP + IPv4 + port
+            DstAddr::V6(..) => 1 + 16 + 2,       // ATYP + IPv6 + port
+            DstAddr::Domain(n, _) => 1 + 1 + n.len() + 2, // ATYP + len + name + port
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Frame {
+    flags: u8,
+    conn_id: u16,
+    addr: Option<DstAddr>,
+    payload: Vec<u8>,
+}
+
+// -------------------------------------------------------------------------
+// Parse / serialise
+// -------------------------------------------------------------------------
+
+/// Try to parse one frame from `buf`. Returns `(frame, bytes_consumed)` or
+/// `None` if the buffer doesn't contain a complete frame yet.
+fn try_parse_frame(buf: &[u8]) -> Result<Option<(Frame, usize)>, std::io::Error> {
+    if buf.len() < 2 {
+        return Ok(None);
+    }
+    let body_len = u16::from_be_bytes([buf[0], buf[1]]) as usize;
+    let total = 2 + body_len;
+    if buf.len() < total {
+        return Ok(None);
+    }
+
+    let body = &buf[2..total];
+    if body.len() < 3 {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "frame too short"));
+    }
+    let flags = body[0];
+    let conn_id = u16::from_be_bytes([body[1], body[2]]);
+    let rest = &body[3..];
+
+    let (addr, payload_start) = if flags & FLAG_DATA != 0 {
+        // Parse SOCKS5-style address.
+        if rest.is_empty() {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "missing ATYP"));
+        }
+        let atyp = rest[0];
+        match atyp {
+            ATYP_IPV4 => {
+                if rest.len() < 1 + 4 + 2 {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "short IPv4 addr"));
+                }
+                let ip = Ipv4Addr::new(rest[1], rest[2], rest[3], rest[4]);
+                let port = u16::from_be_bytes([rest[5], rest[6]]);
+                (Some(DstAddr::V4(ip, port)), 7)
+            }
+            ATYP_IPV6 => {
+                if rest.len() < 1 + 16 + 2 {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "short IPv6 addr"));
+                }
+                let mut octets = [0u8; 16];
+                octets.copy_from_slice(&rest[1..17]);
+                let ip = Ipv6Addr::from(octets);
+                let port = u16::from_be_bytes([rest[17], rest[18]]);
+                (Some(DstAddr::V6(ip, port)), 19)
+            }
+            ATYP_DOMAIN => {
+                if rest.len() < 2 {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "short domain addr"));
+                }
+                let dlen = rest[1] as usize;
+                if rest.len() < 2 + dlen + 2 {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "short domain addr"));
+                }
+                let name = String::from_utf8_lossy(&rest[2..2 + dlen]).into_owned();
+                let port = u16::from_be_bytes([rest[2 + dlen], rest[3 + dlen]]);
+                (Some(DstAddr::Domain(name, port)), 2 + dlen + 2)
+            }
+            _ => {
+                return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, format!("unknown ATYP 0x{:02x}", atyp)));
+            }
+        }
+    } else {
+        (None, 0)
+    };
+
+    let payload = rest[payload_start..].to_vec();
+
+    Ok(Some((Frame { flags, conn_id, addr, payload }, total)))
+}
+
+fn serialise_frame(frame: &Frame) -> Vec<u8> {
+    // Body = flags(1) + conn_id(2) + [addr] + payload
+    let addr_len = frame.addr.as_ref().map_or(0, |a| a.serialised_len());
+    let body_len = 1 + 2 + addr_len + frame.payload.len();
+
+    let mut buf = Vec::with_capacity(2 + body_len);
+    buf.extend_from_slice(&(body_len as u16).to_be_bytes());
+    buf.push(frame.flags);
+    buf.extend_from_slice(&frame.conn_id.to_be_bytes());
+    if let Some(ref addr) = frame.addr {
+        addr.write_to(&mut buf);
+    }
+    buf.extend_from_slice(&frame.payload);
+    buf
+}
+
+// -------------------------------------------------------------------------
+// Public API
+// -------------------------------------------------------------------------
+
+/// Returns `true` if the connect destination is the magic udpgw address.
+pub fn is_udpgw_dest(host: &str, port: u16) -> bool {
+    port == UDPGW_MAGIC_PORT && host == format!("{}.{}.{}.{}", UDPGW_MAGIC_IP[0], UDPGW_MAGIC_IP[1], UDPGW_MAGIC_IP[2], UDPGW_MAGIC_IP[3])
+}
+
+/// Run the udpgw server over a duplex stream. Reads udpgw frames from the
+/// client half, sends real UDP datagrams, and writes response frames back.
+/// Returns when the stream is closed or an unrecoverable error occurs.
+pub async fn udpgw_server_task(stream: DuplexStream) {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+
+    // Writer task: drains response channel → duplex stream.
+    let mut write_half = {
+        // We split manually: the read loop runs inline, the write loop
+        // is a spawned task feeding from `rx`.
+        // tokio DuplexStream doesn't have into_split(), so we use a
+        // channel-based approach instead.
+        let (read_half, write_half) = tokio::io::split(stream);
+        tokio::spawn(async move {
+            let mut w = write_half;
+            while let Some(data) = rx.recv().await {
+                if w.write_all(&data).await.is_err() {
+                    break;
+                }
+                let _ = w.flush().await;
+            }
+        });
+        read_half
+    };
+
+    let mut buf = Vec::with_capacity(65536);
+    let mut tmp = [0u8; 65536];
+
+    loop {
+        // Read more data from the client.
+        let n = match write_half.read(&mut tmp).await {
+            Ok(0) | Err(_) => break,
+            Ok(n) => n,
+        };
+        buf.extend_from_slice(&tmp[..n]);
+
+            // Parse as many complete frames as we can.
+        loop {
+            match try_parse_frame(&buf) {
+                Ok(Some((frame, consumed))) => {
+                    buf.drain(..consumed);
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        handle_frame(frame, tx).await;
+                    });
+                }
+                Ok(None) => break, // need more data
+                Err(e) => {
+                    tracing::warn!("udpgw frame parse error: {}", e);
+                    // Discard the first two bytes (length) and try to
+                    // resync on the next frame.
+                    if buf.len() >= 2 {
+                        let skip = 2 + u16::from_be_bytes([buf[0], buf[1]]) as usize;
+                        let skip = skip.min(buf.len());
+                        buf.drain(..skip);
+                    } else {
+                        buf.clear();
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    tracing::debug!("udpgw session ended");
+}
+
+async fn handle_frame(frame: Frame, tx: tokio::sync::mpsc::Sender<Vec<u8>>) {
+    if frame.flags & FLAG_KEEPALIVE != 0 {
+        let resp = serialise_frame(&Frame {
+            flags: FLAG_KEEPALIVE,
+            conn_id: frame.conn_id,
+            addr: None,
+            payload: vec![],
+        });
+        let _ = tx.send(resp).await;
+        return;
+    }
+
+    if frame.flags & FLAG_DATA == 0 {
+        // Not a data frame and not keepalive — ignore.
+        return;
+    }
+
+    let Some(ref dst) = frame.addr else {
+        let _ = tx.send(serialise_err(frame.conn_id)).await;
+        return;
+    };
+
+    let dst_addr = match dst.to_socket_addr() {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::debug!("udpgw resolve failed: {}", e);
+            let _ = tx.send(serialise_err(frame.conn_id)).await;
+            return;
+        }
+    };
+
+    // Send real UDP and wait for response.
+    match udp_round_trip(&dst_addr, &frame.payload).await {
+        Ok(resp_data) => {
+            let resp = serialise_frame(&Frame {
+                flags: FLAG_DATA,
+                conn_id: frame.conn_id,
+                addr: frame.addr,
+                payload: resp_data,
+            });
+            let _ = tx.send(resp).await;
+        }
+        Err(e) => {
+            tracing::debug!("udpgw udp error to {}: {}", dst_addr, e);
+            let _ = tx.send(serialise_err(frame.conn_id)).await;
+        }
+    }
+}
+
+fn serialise_err(conn_id: u16) -> Vec<u8> {
+    serialise_frame(&Frame {
+        flags: FLAG_ERR,
+        conn_id,
+        addr: None,
+        payload: vec![],
+    })
+}
+
+async fn udp_round_trip(dst: &SocketAddr, payload: &[u8]) -> std::io::Result<Vec<u8>> {
+    let bind_addr: SocketAddr = if dst.is_ipv6() {
+        "[::]:0".parse().unwrap()
+    } else {
+        "0.0.0.0:0".parse().unwrap()
+    };
+    let sock = UdpSocket::bind(bind_addr).await?;
+    sock.send_to(payload, dst).await?;
+
+    let mut buf = vec![0u8; UDP_MTU];
+    let (len, _) = tokio::time::timeout(UDP_TIMEOUT, sock.recv_from(&mut buf))
+        .await
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "udp recv timeout"))??;
+    buf.truncate(len);
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keepalive_round_trip() {
+        let frame = Frame { flags: FLAG_KEEPALIVE, conn_id: 42, addr: None, payload: vec![] };
+        let bytes = serialise_frame(&frame);
+        let (parsed, consumed) = try_parse_frame(&bytes).unwrap().unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(parsed.flags, FLAG_KEEPALIVE);
+        assert_eq!(parsed.conn_id, 42);
+        assert!(parsed.addr.is_none());
+        assert!(parsed.payload.is_empty());
+    }
+
+    #[test]
+    fn data_ipv4_round_trip() {
+        let frame = Frame {
+            flags: FLAG_DATA,
+            conn_id: 7,
+            addr: Some(DstAddr::V4(Ipv4Addr::new(8, 8, 8, 8), 53)),
+            payload: vec![1, 2, 3, 4],
+        };
+        let bytes = serialise_frame(&frame);
+        let (parsed, consumed) = try_parse_frame(&bytes).unwrap().unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(parsed.flags, FLAG_DATA);
+        assert_eq!(parsed.conn_id, 7);
+        assert_eq!(parsed.payload, vec![1, 2, 3, 4]);
+        match parsed.addr.unwrap() {
+            DstAddr::V4(ip, port) => {
+                assert_eq!(ip, Ipv4Addr::new(8, 8, 8, 8));
+                assert_eq!(port, 53);
+            }
+            _ => panic!("expected IPv4"),
+        }
+    }
+
+    #[test]
+    fn data_ipv6_round_trip() {
+        let frame = Frame {
+            flags: FLAG_DATA,
+            conn_id: 100,
+            addr: Some(DstAddr::V6(Ipv6Addr::LOCALHOST, 443)),
+            payload: b"hello".to_vec(),
+        };
+        let bytes = serialise_frame(&frame);
+        let (parsed, _) = try_parse_frame(&bytes).unwrap().unwrap();
+        assert_eq!(parsed.conn_id, 100);
+        match parsed.addr.unwrap() {
+            DstAddr::V6(ip, port) => {
+                assert_eq!(ip, Ipv6Addr::LOCALHOST);
+                assert_eq!(port, 443);
+            }
+            _ => panic!("expected IPv6"),
+        }
+    }
+
+    #[test]
+    fn data_domain_round_trip() {
+        let frame = Frame {
+            flags: FLAG_DATA,
+            conn_id: 5,
+            addr: Some(DstAddr::Domain("example.com".into(), 80)),
+            payload: b"GET /".to_vec(),
+        };
+        let bytes = serialise_frame(&frame);
+        let (parsed, _) = try_parse_frame(&bytes).unwrap().unwrap();
+        match parsed.addr.unwrap() {
+            DstAddr::Domain(name, port) => {
+                assert_eq!(name, "example.com");
+                assert_eq!(port, 80);
+            }
+            _ => panic!("expected Domain"),
+        }
+    }
+
+    #[test]
+    fn err_frame_round_trip() {
+        let bytes = serialise_err(99);
+        let (parsed, _) = try_parse_frame(&bytes).unwrap().unwrap();
+        assert_eq!(parsed.flags, FLAG_ERR);
+        assert_eq!(parsed.conn_id, 99);
+    }
+
+    #[test]
+    fn partial_frame_returns_none() {
+        let frame = Frame { flags: FLAG_KEEPALIVE, conn_id: 1, addr: None, payload: vec![] };
+        let bytes = serialise_frame(&frame);
+        // Give it only half the bytes.
+        assert!(try_parse_frame(&bytes[..bytes.len() / 2]).unwrap().is_none());
+    }
+
+    #[test]
+    fn two_frames_in_buffer() {
+        let f1 = serialise_frame(&Frame { flags: FLAG_KEEPALIVE, conn_id: 1, addr: None, payload: vec![] });
+        let f2 = serialise_frame(&Frame { flags: FLAG_KEEPALIVE, conn_id: 2, addr: None, payload: vec![] });
+        let mut buf = f1.clone();
+        buf.extend_from_slice(&f2);
+
+        let (p1, c1) = try_parse_frame(&buf).unwrap().unwrap();
+        assert_eq!(p1.conn_id, 1);
+        let (p2, _) = try_parse_frame(&buf[c1..]).unwrap().unwrap();
+        assert_eq!(p2.conn_id, 2);
+    }
+
+    #[test]
+    fn is_udpgw_dest_works() {
+        assert!(is_udpgw_dest("198.18.0.1", 7300));
+        assert!(!is_udpgw_dest("198.18.0.1", 80));
+        assert!(!is_udpgw_dest("8.8.8.8", 7300));
+    }
+}


### PR DESCRIPTION
## Summary
- Native udpgw wire protocol in the tunnel-node — UDP forwarding (DNS, QUIC, Meet) through the existing HTTP tunnel, no external binary needed
- Forked tun2proxy JNI adds `udpgw_server` parameter; Android client passes `198.18.0.1:7300` in full mode
- README (EN + FA) and tunnel-node/README: **Cloud Run does not support UDP responses** — use a VPS for udpgw

## Changes

**tunnel-node/src/udpgw.rs** (new)
- Frame parser/serializer for tun2proxy wire format (SOCKS5-style addresses, big-endian)
- `udpgw_server_task` reads frames from duplex channel, sends real UDP, writes responses
- 7 unit tests (round-trip, keepalive, IPv4/IPv6/domain, partial frames)

**tunnel-node/src/main.rs**
- `SessionWriter` enum (TCP or Duplex) replaces hardcoded `OwnedWriteHalf`
- `create_udpgw_session()` via `tokio::io::duplex()` for virtual sessions
- Magic address `198.18.0.1:7300` intercepted in connect handlers
- Generic `reader_task` for both TCP and duplex

**Android**
- tun2proxy fork with udpgw JNI param
- `MhrvVpnService.kt` passes udpgw server in full mode

**Docs**
- VPS vs Cloud Run callout (EN + FA) — Cloud Run drops UDP responses
- tunnel-node/README: udpgw architecture section

## Test plan
- [x] 25 tunnel-node tests pass (7 new udpgw)
- [x] Desktop + Android builds pass
- [x] Verified udpgw frames flow end-to-end on VPS (GCE)
- [x] Confirmed Cloud Run drops UDP; VPS works

🤖 Generated with [Claude Code](https://claude.com/claude-code)