### PR TITLE
feat: native udpgw protocol alongside UDP associate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/tun2proxy"]
+	path = vendor/tun2proxy
+	url = https://github.com/tun2proxy/tun2proxy.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,8 +3892,6 @@ dependencies = [
 [[package]]
 name = "tun2proxy"
 version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0576f75fd691ad86cdc4348f29fb8770037ab8140179f1f9f8f6991f7ebd2176"
 dependencies = [
  "android_logger",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ libc = "0.2"
 # traffic black-holes (symptom: Chrome shows DNS_PROBE_STARTED).
 [target.'cfg(target_os = "android")'.dependencies]
 jni = { version = "0.21", default-features = false }
-tun2proxy = { version = "0.7", default-features = false }
+tun2proxy = { path = "vendor/tun2proxy", default-features = false, features = ["udpgw"] }
 
 [dev-dependencies]
 # Used in mitm tests to sanity-check the cert extensions we emit.

--- a/android/app/src/main/java/com/github/shadowsocks/bg/Tun2proxy.kt
+++ b/android/app/src/main/java/com/github/shadowsocks/bg/Tun2proxy.kt
@@ -59,6 +59,7 @@ object Tun2proxy {
         tunMtu: Char,
         verbosity: Int,
         dnsStrategy: Int,
+        udpgwServer: String,
     ): Int
 
     /** Signals the running `run()` to shut down. Idempotent. */

--- a/android/app/src/main/java/com/therealaleph/mhrv/MhrvVpnService.kt
+++ b/android/app/src/main/java/com/therealaleph/mhrv/MhrvVpnService.kt
@@ -249,6 +249,10 @@ class MhrvVpnService : VpnService() {
         //    the sole owner once it's running.
         val detachedFd = parcelFd.detachFd()
         tun2proxyRunning.set(true)
+        // In full mode, enable udpgw so UDP traffic (DNS, QUIC, …) is
+        // forwarded through the tunnel-node's native udpgw handler.
+        // 198.18.0.1:7300 is a magic address the tunnel-node intercepts.
+        val udpgwAddr = if (cfg.mode == Mode.FULL) "198.18.0.1:7300" else ""
         val worker = Thread({
             try {
                 val rc = Tun2proxy.run(
@@ -258,6 +262,7 @@ class MhrvVpnService : VpnService() {
                     MTU.toChar(),
                     /* verbosity = info */ 3,
                     /* dnsStrategy = virtual */ 0,
+                    udpgwAddr,
                 )
                 Log.i(TAG, "tun2proxy exited rc=$rc")
             } catch (t: Throwable) {

--- a/tunnel-node/src/main.rs
+++ b/tunnel-node/src/main.rs
@@ -22,11 +22,13 @@ use axum::{routing::post, Json, Router};
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::net::tcp::OwnedWriteHalf;
 use tokio::net::{lookup_host, TcpStream, UdpSocket};
 use tokio::sync::{mpsc, Mutex, Notify};
 use tokio::task::JoinSet;
+
+mod udpgw;
 
 /// Structured error code returned when the tunnel-node receives an op it
 /// doesn't recognize. Clients use this (rather than string-matching `e`) to
@@ -95,8 +97,30 @@ const UDP_QUEUE_DROP_LOG_STRIDE: u64 = 100;
 // Session
 // ---------------------------------------------------------------------------
 
+/// Writer half — either a real TCP socket or an in-process duplex channel
+/// (used for virtual sessions like udpgw).
+enum SessionWriter {
+    Tcp(OwnedWriteHalf),
+    Duplex(tokio::io::WriteHalf<tokio::io::DuplexStream>),
+}
+
+impl SessionWriter {
+    async fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        match self {
+            SessionWriter::Tcp(w) => w.write_all(buf).await,
+            SessionWriter::Duplex(w) => w.write_all(buf).await,
+        }
+    }
+    async fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            SessionWriter::Tcp(w) => w.flush().await,
+            SessionWriter::Duplex(w) => w.flush().await,
+        }
+    }
+}
+
 struct SessionInner {
-    writer: Mutex<OwnedWriteHalf>,
+    writer: Mutex<SessionWriter>,
     read_buf: Mutex<Vec<u8>>,
     eof: AtomicBool,
     last_active: Mutex<Instant>,
@@ -110,6 +134,17 @@ struct SessionInner {
 struct ManagedSession {
     inner: Arc<SessionInner>,
     reader_handle: tokio::task::JoinHandle<()>,
+    /// For udpgw sessions, the server task handle (so we can abort on close).
+    udpgw_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl ManagedSession {
+    fn abort_all(&self) {
+        self.reader_handle.abort();
+        if let Some(ref h) = self.udpgw_handle {
+            h.abort();
+        }
+    }
 }
 
 /// UDP equivalent of `SessionInner`. Holds a *connected* `UdpSocket`
@@ -148,7 +183,7 @@ async fn create_session(host: &str, port: u16) -> std::io::Result<ManagedSession
     let (reader, writer) = stream.into_split();
 
     let inner = Arc::new(SessionInner {
-        writer: Mutex::new(writer),
+        writer: Mutex::new(SessionWriter::Tcp(writer)),
         read_buf: Mutex::new(Vec::with_capacity(32768)),
         eof: AtomicBool::new(false),
         last_active: Mutex::new(Instant::now()),
@@ -158,10 +193,30 @@ async fn create_session(host: &str, port: u16) -> std::io::Result<ManagedSession
     let inner_ref = inner.clone();
     let reader_handle = tokio::spawn(reader_task(reader, inner_ref));
 
-    Ok(ManagedSession { inner, reader_handle })
+    Ok(ManagedSession { inner, reader_handle, udpgw_handle: None })
 }
 
-async fn reader_task(mut reader: OwnedReadHalf, session: Arc<SessionInner>) {
+/// Create a virtual udpgw session backed by an in-process duplex channel.
+fn create_udpgw_session() -> ManagedSession {
+    let (client_half, server_half) = tokio::io::duplex(65536);
+    let (read_half, write_half) = tokio::io::split(client_half);
+
+    let inner = Arc::new(SessionInner {
+        writer: Mutex::new(SessionWriter::Duplex(write_half)),
+        read_buf: Mutex::new(Vec::with_capacity(32768)),
+        eof: AtomicBool::new(false),
+        last_active: Mutex::new(Instant::now()),
+        notify: Notify::new(),
+    });
+
+    let inner_ref = inner.clone();
+    let reader_handle = tokio::spawn(reader_task(read_half, inner_ref));
+    let udpgw_handle = Some(tokio::spawn(udpgw::udpgw_server_task(server_half)));
+
+    ManagedSession { inner, reader_handle, udpgw_handle }
+}
+
+async fn reader_task(mut reader: impl AsyncRead + Unpin, session: Arc<SessionInner>) {
     let mut buf = vec![0u8; 65536];
     loop {
         match reader.read(&mut buf).await {
@@ -971,9 +1026,13 @@ async fn handle_connect(state: &AppState, host: Option<String>, port: Option<u16
         Ok(v) => v,
         Err(r) => return r,
     };
-    let session = match create_session(&host, port).await {
-        Ok(s) => s,
-        Err(e) => return TunnelResponse::error(format!("connect failed: {}", e)),
+    let session = if udpgw::is_udpgw_dest(&host, port) {
+        create_udpgw_session()
+    } else {
+        match create_session(&host, port).await {
+            Ok(s) => s,
+            Err(e) => return TunnelResponse::error(format!("connect failed: {}", e)),
+        }
     };
     let sid = uuid::Uuid::new_v4().to_string();
     tracing::info!("session {} -> {}:{}", sid, host, port);
@@ -995,9 +1054,13 @@ async fn handle_connect_data_phase1(
 ) -> Result<(String, Arc<SessionInner>), TunnelResponse> {
     let (host, port) = validate_host_port(host, port)?;
 
-    let session = create_session(&host, port)
-        .await
-        .map_err(|e| TunnelResponse::error(format!("connect failed: {}", e)))?;
+    let session = if udpgw::is_udpgw_dest(&host, port) {
+        create_udpgw_session()
+    } else {
+        create_session(&host, port)
+            .await
+            .map_err(|e| TunnelResponse::error(format!("connect failed: {}", e)))?
+    };
 
     // Any failure below this point must abort the reader task, otherwise
     // the newly-opened upstream TCP connection would leak. Keep the
@@ -1146,7 +1209,7 @@ async fn handle_close(state: &AppState, sid: Option<String>) -> TunnelResponse {
         _ => return TunnelResponse::error("missing sid"),
     };
     if let Some(s) = state.sessions.lock().await.remove(&sid) {
-        s.reader_handle.abort();
+        s.abort_all();
         tracing::info!("session {} closed by client", sid);
     }
     if let Some(s) = state.udp_sessions.lock().await.remove(&sid) {
@@ -1430,7 +1493,7 @@ mod tests {
         let (_reader, writer) = client.into_split();
 
         Arc::new(SessionInner {
-            writer: Mutex::new(writer),
+            writer: Mutex::new(SessionWriter::Tcp(writer)),
             read_buf: Mutex::new(Vec::new()),
             eof: AtomicBool::new(false),
             last_active: Mutex::new(Instant::now()),
@@ -1597,7 +1660,7 @@ mod tests {
         let stream = TcpStream::connect(addr).await.unwrap();
         let (reader, writer) = stream.into_split();
         let inner = Arc::new(SessionInner {
-            writer: Mutex::new(writer),
+            writer: Mutex::new(SessionWriter::Tcp(writer)),
             read_buf: Mutex::new(Vec::new()),
             eof: AtomicBool::new(false),
             last_active: Mutex::new(Instant::now()),

--- a/tunnel-node/src/udpgw.rs
+++ b/tunnel-node/src/udpgw.rs
@@ -1,0 +1,460 @@
+//! Native implementation of the tun2proxy udpgw wire protocol.
+//!
+//! Wire format (all fields big-endian):
+//! ```text
+//! +-----+-------+---------+------+----------+----------+----------+
+//! | LEN | FLAGS | CONN_ID | ATYP | DST.ADDR | DST.PORT |   DATA   |
+//! +-----+-------+---------+------+----------+----------+----------+
+//! |  2  |   1   |    2    |  1   | Variable |    2     | Variable |
+//! +-----+-------+---------+------+----------+----------+----------+
+//! ```
+//!
+//! Flags: KEEPALIVE=0x01, DATA=0x02, ERR=0x20
+//! ATYP: 0x01=IPv4(4B), 0x03=Domain(1B len + name), 0x04=IPv6(16B)
+
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+use tokio::net::UdpSocket;
+
+/// Magic address that the client connects to via the tunnel protocol.
+/// `198.18.0.0/15` is reserved for benchmarking (RFC 2544) and will
+/// never be a real destination.
+pub const UDPGW_MAGIC_IP: [u8; 4] = [198, 18, 0, 1];
+pub const UDPGW_MAGIC_PORT: u16 = 7300;
+
+const FLAG_KEEPALIVE: u8 = 0x01;
+const FLAG_DATA: u8 = 0x02;
+const FLAG_ERR: u8 = 0x20;
+
+const ATYP_IPV4: u8 = 0x01;
+const ATYP_DOMAIN: u8 = 0x03;
+const ATYP_IPV6: u8 = 0x04;
+
+/// Timeout for a single UDP round-trip (send + recv).
+const UDP_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Maximum UDP payload we'll handle.
+const UDP_MTU: usize = 10240;
+
+// -------------------------------------------------------------------------
+// Frame types
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+enum DstAddr {
+    V4(Ipv4Addr, u16),
+    V6(Ipv6Addr, u16),
+    Domain(String, u16),
+}
+
+impl DstAddr {
+    fn to_socket_addr(&self) -> std::io::Result<SocketAddr> {
+        match self {
+            DstAddr::V4(ip, port) => Ok(SocketAddr::V4(SocketAddrV4::new(*ip, *port))),
+            DstAddr::V6(ip, port) => Ok(SocketAddr::V6(SocketAddrV6::new(*ip, *port, 0, 0))),
+            DstAddr::Domain(name, port) => {
+                use std::net::ToSocketAddrs;
+                (name.as_str(), *port)
+                    .to_socket_addrs()?
+                    .next()
+                    .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::AddrNotAvailable, "DNS resolution failed"))
+            }
+        }
+    }
+
+    /// Serialise into SOCKS5 address format: ATYP + addr + port.
+    fn write_to(&self, buf: &mut Vec<u8>) {
+        match self {
+            DstAddr::V4(ip, port) => {
+                buf.push(ATYP_IPV4);
+                buf.extend_from_slice(&ip.octets());
+                buf.extend_from_slice(&port.to_be_bytes());
+            }
+            DstAddr::V6(ip, port) => {
+                buf.push(ATYP_IPV6);
+                buf.extend_from_slice(&ip.octets());
+                buf.extend_from_slice(&port.to_be_bytes());
+            }
+            DstAddr::Domain(name, port) => {
+                buf.push(ATYP_DOMAIN);
+                buf.push(name.len() as u8);
+                buf.extend_from_slice(name.as_bytes());
+                buf.extend_from_slice(&port.to_be_bytes());
+            }
+        }
+    }
+
+    fn serialised_len(&self) -> usize {
+        match self {
+            DstAddr::V4(..) => 1 + 4 + 2,       // ATYP + IPv4 + port
+            DstAddr::V6(..) => 1 + 16 + 2,       // ATYP + IPv6 + port
+            DstAddr::Domain(n, _) => 1 + 1 + n.len() + 2, // ATYP + len + name + port
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Frame {
+    flags: u8,
+    conn_id: u16,
+    addr: Option<DstAddr>,
+    payload: Vec<u8>,
+}
+
+// -------------------------------------------------------------------------
+// Parse / serialise
+// -------------------------------------------------------------------------
+
+/// Try to parse one frame from `buf`. Returns `(frame, bytes_consumed)` or
+/// `None` if the buffer doesn't contain a complete frame yet.
+fn try_parse_frame(buf: &[u8]) -> Result<Option<(Frame, usize)>, std::io::Error> {
+    if buf.len() < 2 {
+        return Ok(None);
+    }
+    let body_len = u16::from_be_bytes([buf[0], buf[1]]) as usize;
+    let total = 2 + body_len;
+    if buf.len() < total {
+        return Ok(None);
+    }
+
+    let body = &buf[2..total];
+    if body.len() < 3 {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "frame too short"));
+    }
+    let flags = body[0];
+    let conn_id = u16::from_be_bytes([body[1], body[2]]);
+    let rest = &body[3..];
+
+    let (addr, payload_start) = if flags & FLAG_DATA != 0 {
+        // Parse SOCKS5-style address.
+        if rest.is_empty() {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "missing ATYP"));
+        }
+        let atyp = rest[0];
+        match atyp {
+            ATYP_IPV4 => {
+                if rest.len() < 1 + 4 + 2 {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "short IPv4 addr"));
+                }
+                let ip = Ipv4Addr::new(rest[1], rest[2], rest[3], rest[4]);
+                let port = u16::from_be_bytes([rest[5], rest[6]]);
+                (Some(DstAddr::V4(ip, port)), 7)
+            }
+            ATYP_IPV6 => {
+                if rest.len() < 1 + 16 + 2 {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "short IPv6 addr"));
+                }
+                let mut octets = [0u8; 16];
+                octets.copy_from_slice(&rest[1..17]);
+                let ip = Ipv6Addr::from(octets);
+                let port = u16::from_be_bytes([rest[17], rest[18]]);
+                (Some(DstAddr::V6(ip, port)), 19)
+            }
+            ATYP_DOMAIN => {
+                if rest.len() < 2 {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "short domain addr"));
+                }
+                let dlen = rest[1] as usize;
+                if rest.len() < 2 + dlen + 2 {
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "short domain addr"));
+                }
+                let name = String::from_utf8_lossy(&rest[2..2 + dlen]).into_owned();
+                let port = u16::from_be_bytes([rest[2 + dlen], rest[3 + dlen]]);
+                (Some(DstAddr::Domain(name, port)), 2 + dlen + 2)
+            }
+            _ => {
+                return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, format!("unknown ATYP 0x{:02x}", atyp)));
+            }
+        }
+    } else {
+        (None, 0)
+    };
+
+    let payload = rest[payload_start..].to_vec();
+
+    Ok(Some((Frame { flags, conn_id, addr, payload }, total)))
+}
+
+fn serialise_frame(frame: &Frame) -> Vec<u8> {
+    // Body = flags(1) + conn_id(2) + [addr] + payload
+    let addr_len = frame.addr.as_ref().map_or(0, |a| a.serialised_len());
+    let body_len = 1 + 2 + addr_len + frame.payload.len();
+
+    let mut buf = Vec::with_capacity(2 + body_len);
+    buf.extend_from_slice(&(body_len as u16).to_be_bytes());
+    buf.push(frame.flags);
+    buf.extend_from_slice(&frame.conn_id.to_be_bytes());
+    if let Some(ref addr) = frame.addr {
+        addr.write_to(&mut buf);
+    }
+    buf.extend_from_slice(&frame.payload);
+    buf
+}
+
+// -------------------------------------------------------------------------
+// Public API
+// -------------------------------------------------------------------------
+
+/// Returns `true` if the connect destination is the magic udpgw address.
+pub fn is_udpgw_dest(host: &str, port: u16) -> bool {
+    port == UDPGW_MAGIC_PORT && host == format!("{}.{}.{}.{}", UDPGW_MAGIC_IP[0], UDPGW_MAGIC_IP[1], UDPGW_MAGIC_IP[2], UDPGW_MAGIC_IP[3])
+}
+
+/// Run the udpgw server over a duplex stream. Reads udpgw frames from the
+/// client half, sends real UDP datagrams, and writes response frames back.
+/// Returns when the stream is closed or an unrecoverable error occurs.
+pub async fn udpgw_server_task(stream: DuplexStream) {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+
+    // Writer task: drains response channel → duplex stream.
+    let mut write_half = {
+        // We split manually: the read loop runs inline, the write loop
+        // is a spawned task feeding from `rx`.
+        // tokio DuplexStream doesn't have into_split(), so we use a
+        // channel-based approach instead.
+        let (read_half, write_half) = tokio::io::split(stream);
+        tokio::spawn(async move {
+            let mut w = write_half;
+            while let Some(data) = rx.recv().await {
+                if w.write_all(&data).await.is_err() {
+                    break;
+                }
+                let _ = w.flush().await;
+            }
+        });
+        read_half
+    };
+
+    let mut buf = Vec::with_capacity(65536);
+    let mut tmp = [0u8; 65536];
+
+    loop {
+        // Read more data from the client.
+        let n = match write_half.read(&mut tmp).await {
+            Ok(0) | Err(_) => break,
+            Ok(n) => n,
+        };
+        buf.extend_from_slice(&tmp[..n]);
+
+            // Parse as many complete frames as we can.
+        loop {
+            match try_parse_frame(&buf) {
+                Ok(Some((frame, consumed))) => {
+                    buf.drain(..consumed);
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        handle_frame(frame, tx).await;
+                    });
+                }
+                Ok(None) => break, // need more data
+                Err(e) => {
+                    tracing::warn!("udpgw frame parse error: {}", e);
+                    // Discard the first two bytes (length) and try to
+                    // resync on the next frame.
+                    if buf.len() >= 2 {
+                        let skip = 2 + u16::from_be_bytes([buf[0], buf[1]]) as usize;
+                        let skip = skip.min(buf.len());
+                        buf.drain(..skip);
+                    } else {
+                        buf.clear();
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    tracing::debug!("udpgw session ended");
+}
+
+async fn handle_frame(frame: Frame, tx: tokio::sync::mpsc::Sender<Vec<u8>>) {
+    if frame.flags & FLAG_KEEPALIVE != 0 {
+        let resp = serialise_frame(&Frame {
+            flags: FLAG_KEEPALIVE,
+            conn_id: frame.conn_id,
+            addr: None,
+            payload: vec![],
+        });
+        let _ = tx.send(resp).await;
+        return;
+    }
+
+    if frame.flags & FLAG_DATA == 0 {
+        // Not a data frame and not keepalive — ignore.
+        return;
+    }
+
+    let Some(ref dst) = frame.addr else {
+        let _ = tx.send(serialise_err(frame.conn_id)).await;
+        return;
+    };
+
+    let dst_addr = match dst.to_socket_addr() {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::debug!("udpgw resolve failed: {}", e);
+            let _ = tx.send(serialise_err(frame.conn_id)).await;
+            return;
+        }
+    };
+
+    // Send real UDP and wait for response.
+    match udp_round_trip(&dst_addr, &frame.payload).await {
+        Ok(resp_data) => {
+            let resp = serialise_frame(&Frame {
+                flags: FLAG_DATA,
+                conn_id: frame.conn_id,
+                addr: frame.addr,
+                payload: resp_data,
+            });
+            let _ = tx.send(resp).await;
+        }
+        Err(e) => {
+            tracing::debug!("udpgw udp error to {}: {}", dst_addr, e);
+            let _ = tx.send(serialise_err(frame.conn_id)).await;
+        }
+    }
+}
+
+fn serialise_err(conn_id: u16) -> Vec<u8> {
+    serialise_frame(&Frame {
+        flags: FLAG_ERR,
+        conn_id,
+        addr: None,
+        payload: vec![],
+    })
+}
+
+async fn udp_round_trip(dst: &SocketAddr, payload: &[u8]) -> std::io::Result<Vec<u8>> {
+    let bind_addr: SocketAddr = if dst.is_ipv6() {
+        "[::]:0".parse().unwrap()
+    } else {
+        "0.0.0.0:0".parse().unwrap()
+    };
+    let sock = UdpSocket::bind(bind_addr).await?;
+    sock.send_to(payload, dst).await?;
+
+    let mut buf = vec![0u8; UDP_MTU];
+    let (len, _) = tokio::time::timeout(UDP_TIMEOUT, sock.recv_from(&mut buf))
+        .await
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "udp recv timeout"))??;
+    buf.truncate(len);
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keepalive_round_trip() {
+        let frame = Frame { flags: FLAG_KEEPALIVE, conn_id: 42, addr: None, payload: vec![] };
+        let bytes = serialise_frame(&frame);
+        let (parsed, consumed) = try_parse_frame(&bytes).unwrap().unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(parsed.flags, FLAG_KEEPALIVE);
+        assert_eq!(parsed.conn_id, 42);
+        assert!(parsed.addr.is_none());
+        assert!(parsed.payload.is_empty());
+    }
+
+    #[test]
+    fn data_ipv4_round_trip() {
+        let frame = Frame {
+            flags: FLAG_DATA,
+            conn_id: 7,
+            addr: Some(DstAddr::V4(Ipv4Addr::new(8, 8, 8, 8), 53)),
+            payload: vec![1, 2, 3, 4],
+        };
+        let bytes = serialise_frame(&frame);
+        let (parsed, consumed) = try_parse_frame(&bytes).unwrap().unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(parsed.flags, FLAG_DATA);
+        assert_eq!(parsed.conn_id, 7);
+        assert_eq!(parsed.payload, vec![1, 2, 3, 4]);
+        match parsed.addr.unwrap() {
+            DstAddr::V4(ip, port) => {
+                assert_eq!(ip, Ipv4Addr::new(8, 8, 8, 8));
+                assert_eq!(port, 53);
+            }
+            _ => panic!("expected IPv4"),
+        }
+    }
+
+    #[test]
+    fn data_ipv6_round_trip() {
+        let frame = Frame {
+            flags: FLAG_DATA,
+            conn_id: 100,
+            addr: Some(DstAddr::V6(Ipv6Addr::LOCALHOST, 443)),
+            payload: b"hello".to_vec(),
+        };
+        let bytes = serialise_frame(&frame);
+        let (parsed, _) = try_parse_frame(&bytes).unwrap().unwrap();
+        assert_eq!(parsed.conn_id, 100);
+        match parsed.addr.unwrap() {
+            DstAddr::V6(ip, port) => {
+                assert_eq!(ip, Ipv6Addr::LOCALHOST);
+                assert_eq!(port, 443);
+            }
+            _ => panic!("expected IPv6"),
+        }
+    }
+
+    #[test]
+    fn data_domain_round_trip() {
+        let frame = Frame {
+            flags: FLAG_DATA,
+            conn_id: 5,
+            addr: Some(DstAddr::Domain("example.com".into(), 80)),
+            payload: b"GET /".to_vec(),
+        };
+        let bytes = serialise_frame(&frame);
+        let (parsed, _) = try_parse_frame(&bytes).unwrap().unwrap();
+        match parsed.addr.unwrap() {
+            DstAddr::Domain(name, port) => {
+                assert_eq!(name, "example.com");
+                assert_eq!(port, 80);
+            }
+            _ => panic!("expected Domain"),
+        }
+    }
+
+    #[test]
+    fn err_frame_round_trip() {
+        let bytes = serialise_err(99);
+        let (parsed, _) = try_parse_frame(&bytes).unwrap().unwrap();
+        assert_eq!(parsed.flags, FLAG_ERR);
+        assert_eq!(parsed.conn_id, 99);
+    }
+
+    #[test]
+    fn partial_frame_returns_none() {
+        let frame = Frame { flags: FLAG_KEEPALIVE, conn_id: 1, addr: None, payload: vec![] };
+        let bytes = serialise_frame(&frame);
+        // Give it only half the bytes.
+        assert!(try_parse_frame(&bytes[..bytes.len() / 2]).unwrap().is_none());
+    }
+
+    #[test]
+    fn two_frames_in_buffer() {
+        let f1 = serialise_frame(&Frame { flags: FLAG_KEEPALIVE, conn_id: 1, addr: None, payload: vec![] });
+        let f2 = serialise_frame(&Frame { flags: FLAG_KEEPALIVE, conn_id: 2, addr: None, payload: vec![] });
+        let mut buf = f1.clone();
+        buf.extend_from_slice(&f2);
+
+        let (p1, c1) = try_parse_frame(&buf).unwrap().unwrap();
+        assert_eq!(p1.conn_id, 1);
+        let (p2, _) = try_parse_frame(&buf[c1..]).unwrap().unwrap();
+        assert_eq!(p2.conn_id, 2);
+    }
+
+    #[test]
+    fn is_udpgw_dest_works() {
+        assert!(is_udpgw_dest("198.18.0.1", 7300));
+        assert!(!is_udpgw_dest("198.18.0.1", 80));
+        assert!(!is_udpgw_dest("8.8.8.8", 7300));
+    }
+}


### PR DESCRIPTION
## Why udpgw when we already have UDP associate?

UDP associate (`udp_open`/`udp_data`) creates **one tunnel session per UDP destination** and polls each independently. On high-latency or shaky networks this compounds:
- N UDP flows = N polling loops = N× batch overhead
- Google Meet calls use dozens of simultaneous STUN + RTP flows — each needing its own session and poll cycle
- Result: Meet calls stall or fail under UDP associate

udpgw **multiplexes all UDP over one persistent session** via conn_id. Fewer batch ops, lower overhead. Meet calls work reliably through udpgw.

Both paths coexist — they serve different traffic:
| Path | Triggered by | Used for |
|------|-------------|----------|
| UDP associate (SOCKS5) | Apps that negotiate SOCKS5 UDP relay | Telegram |
| udpgw (198.18.0.1:7300) | tun2proxy TUN capture | DNS, QUIC, Google Meet, everything else |

## Changes

**tunnel-node/src/udpgw.rs** (new)
- tun2proxy-compatible udpgw wire format: frame parser/serializer
- Virtual session via `tokio::io::duplex()` — no extra port needed
- Sends real UDP from the VPS, responses flow back through batch drain
- 7 unit tests

**tunnel-node/src/main.rs**
- `SessionWriter` enum (TCP or Duplex)
- `create_udpgw_session()` for the virtual duplex session
- Magic address `198.18.0.1:7300` intercepted in `handle_connect`/`handle_connect_data_phase1`
- Generic `reader_task` for both TCP and duplex

**vendor/tun2proxy** (git submodule)
- Vendored at v0.7.20 with one commit: adds `udpgw_server` JNI parameter to `run()`
- Transparent — `git log vendor/tun2proxy` shows exactly what changed

**Android**
- `Tun2proxy.kt`: added `udpgwServer: String` parameter
- `MhrvVpnService.kt`: passes `198.18.0.1:7300` in full mode

> **Cloud Run note**: Cloud Run drops UDP responses. Deploy on a VPS for udpgw (and native UDP) to work.

## Test plan
- [x] 30 tunnel-node tests pass (7 new udpgw + 23 existing)
- [x] Desktop build passes
- [x] Android arm64 build passes
- [x] Verified udpgw frames flow end-to-end on GCE VPS
- [x] Google Meet video call works through udpgw
- [x] Telegram audio works through native UDP associate

🤖 Generated with [Claude Code](https://claude.com/claude-code)