### PR TITLE
fix: add twitter.com

### DIFF
--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -1862,7 +1862,7 @@ where
     // pourya-p's log in #64 showed the real Host header. Match every
     // subdomain of x.com here.
     let host_lower = host.to_ascii_lowercase();
-    let is_x_com = host_lower == "x.com" || host_lower.ends_with(".x.com");
+    let is_x_com = host_lower == "x.com" || host_lower.ends_with(".x.com") || host_lower == "twitter.com" || host_lower.ends_with(".twitter.com");
     let path = if is_x_com && path.starts_with("/i/api/graphql/") && path.contains("?variables=") {
         match path.split_once('&') {
             Some((short, _)) => {


### PR DESCRIPTION
Hi there, I added twitter.com there is a reason if you use a extension that has the option to redirect to twitter.com like Control Panel for Twitter it will not do the shortening.
<img width="1080" height="2218" alt="Screenshot_20260426_105846_Fennec" src="https://github.com/user-attachments/assets/cb5a4c4c-b908-4c11-9f43-a96ed0166308" />