### PR TITLE
feat: added ability to copy logs in android

### DIFF
--- a/android/app/src/main/java/com/therealaleph/mhrv/ui/HomeScreen.kt
+++ b/android/app/src/main/java/com/therealaleph/mhrv/ui/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.therealaleph.mhrv.ui
 
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -9,6 +10,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
@@ -23,7 +25,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -1231,6 +1235,8 @@ private fun LiveLogPane() {
     val lines = remember { mutableStateListOf<String>() }
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
+    val clipboard = LocalClipboardManager.current
+    val ctx = LocalContext.current
 
     // Pull from the ring buffer periodically. We pull even while the
     // section is collapsed (cheap), so re-expanding shows fresh tail.
@@ -1260,24 +1266,41 @@ private fun LiveLogPane() {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.weight(1f),
             )
-            TextButton(onClick = { lines.clear() }) { Text("Clear") }
+            TextButton(
+                enabled = lines.isNotEmpty(),
+                onClick = {
+                    clipboard.setText(AnnotatedString(lines.joinToString("\n")))
+                    Toast.makeText(
+                        ctx,
+                        ctx.getString(R.string.snack_logs_copied),
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                },
+            ) { Text(stringResource(R.string.btn_copy)) }
+            TextButton(onClick = { lines.clear() }) { Text(stringResource(R.string.btn_clear)) }
         }
         Surface(
             color = MaterialTheme.colorScheme.surfaceVariant,
             shape = RoundedCornerShape(8.dp),
             modifier = Modifier.fillMaxWidth().heightIn(min = 160.dp, max = 320.dp),
         ) {
-            LazyColumn(
-                state = listState,
-                modifier = Modifier.padding(8.dp),
-            ) {
-                items(lines) { line ->
-                    Text(
-                        line,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontFamily = FontFamily.Monospace,
-                        fontSize = 11.sp,
-                    )
+            // SelectionContainer makes log lines selectable for manual
+            // copy of partial ranges. Cross-line selection works within the
+            // currently rendered window; for "copy everything" the Copy
+            // button above is the reliable path.
+            SelectionContainer {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.padding(8.dp),
+                ) {
+                    items(lines) { line ->
+                        Text(
+                            line,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = 11.sp,
+                        )
+                    }
                 }
             }
         }

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -24,6 +24,7 @@
     <string name="btn_test">تست</string>
     <string name="btn_add">افزودن</string>
     <string name="btn_clear">پاک</string>
+    <string name="btn_copy">کپی</string>
     <string name="btn_install">نصب</string>
     <string name="btn_cancel">انصراف</string>
 
@@ -78,6 +79,7 @@
     <string name="snack_google_ip_updated">google_ip به %1$s به‌روزرسانی شد</string>
     <string name="snack_google_ip_current">google_ip قبلاً به‌روز است (%1$s)</string>
     <string name="snack_dns_lookup_failed">خطای DNS — اتصال شبکه را بررسی کنید</string>
+    <string name="snack_logs_copied">لاگ‌ها در کلیپ‌بورد کپی شدند</string>
 
     <!-- Usage today card -->
     <string name="sec_usage_today">مصرف امروز (تخمینی)</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="btn_test">Test</string>
     <string name="btn_add">Add</string>
     <string name="btn_clear">Clear</string>
+    <string name="btn_copy">Copy</string>
     <string name="btn_install">Install</string>
     <string name="btn_cancel">Cancel</string>
 
@@ -78,6 +79,7 @@
     <string name="snack_google_ip_updated">google_ip updated to %1$s</string>
     <string name="snack_google_ip_current">google_ip already current (%1$s)</string>
     <string name="snack_dns_lookup_failed">DNS lookup failed — check network</string>
+    <string name="snack_logs_copied">Logs copied to clipboard</string>
 
     <!-- Usage today card -->
     <string name="sec_usage_today">Usage today (estimated)</string>


### PR DESCRIPTION
## Summary

Adds a **Copy** button to the live log pane on Android and makes the log lines selectable. Until now, getting logs off the device required tethering with `adb logcat` — the on-screen text wasn't selectable and there was no copy affordance, so users couldn't share a snippet from the app itself.

## Changes

- **Copy button** next to "Clear" in the live log header. Joins the buffered lines (capped at 500 by the existing ring) with `\n`, writes them to the system clipboard via `LocalClipboardManager`, and shows a Toast confirming the copy. Disabled when the buffer is empty so we don't push an empty string onto the clipboard.
- **Selectable text**: the log `LazyColumn` is wrapped in a `SelectionContainer`, so users can long-press to grab a partial range. Cross-line selection works within the rendered window — for "copy everything" the new button is the reliable path, which is why both exist.
- Replaced the hardcoded `"Clear"` button label with `stringResource(R.string.btn_clear)` so the new Copy/Clear pair stay locale-consistent (Persian was already defined for `btn_clear`).
- New strings `btn_copy` and `snack_logs_copied` in both `values/strings.xml` and `values-fa/strings.xml`.

## Files touched

- `android/app/src/main/java/com/therealaleph/mhrv/ui/HomeScreen.kt` — `LiveLogPane` button + SelectionContainer
- `android/app/src/main/res/values/strings.xml`, `android/app/src/main/res/values-fa/strings.xml` — new strings

