### PR TITLE
ci: add i686-pc-windows-msvc to release matrix (#272)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,9 @@ jobs:
           - target: x86_64-pc-windows-gnu
             os: windows-latest
             name: mhrv-rs-windows-amd64
+          - target: i686-pc-windows-msvc
+            os: windows-latest
+            name: mhrv-rs-windows-i686  
           - target: x86_64-unknown-linux-musl
             os: [self-hosted, linux, x64, mhrv-build]
             name: mhrv-rs-linux-musl-amd64


### PR DESCRIPTION
Closes https://github.com/therealaleph/MasterHttpRelayVPN-RUST/issues/272. Adds 32-bit Windows binary to the release matrix per user request.