### PR TITLE
ci(release): pin i686-pc-windows-msvc to Rust 1.77.2 for Win7 compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,16 @@ jobs:
             name: mhrv-rs-windows-amd64
           - target: i686-pc-windows-msvc
             os: windows-latest
-            name: mhrv-rs-windows-i686  
+            name: mhrv-rs-windows-i686
+            # Pin Rust 1.77.2 specifically for this target. Rust 1.78
+            # (May 2024) raised the Windows MSRV from Win7 to Win10 by
+            # switching std::time to GetSystemTimePreciseAsFileTime, a
+            # kernel32 export that doesn't exist on Win7. The whole
+            # reason this target ships is to support legacy Win7 32-bit
+            # boxes (#272), so a stock-stable build defeats the purpose.
+            # 1.77.2 is the last stable that produces a Win7-loadable
+            # binary; other targets stay on @stable. (Fixes #318.)
+            rust_toolchain: "1.77.2"
           - target: x86_64-unknown-linux-musl
             os: [self-hosted, linux, x64, mhrv-build]
             name: mhrv-rs-linux-musl-amd64
@@ -141,9 +150,14 @@ jobs:
       # installed and the standard target triples are pre-added. It
       # still verifies the target is present and is cheap enough to keep
       # as a safety net.
-      - uses: dtolnay/rust-toolchain@stable
+      # Per-matrix-entry toolchain selection. Default is `stable` (latest)
+      # for every target except where `rust_toolchain` is explicitly pinned
+      # — currently just i686-pc-windows-msvc, which needs 1.77.2 to keep
+      # the Win7 binary loadable (Rust 1.78+ raised Windows MSRV to Win10).
+      - uses: dtolnay/rust-toolchain@master
         if: matrix.mipsel_softfloat != true
         with:
+          toolchain: ${{ matrix.rust_toolchain || 'stable' }}
           targets: ${{ matrix.target }}
 
       # Cache target/ + cargo registry across runs — this is the big
@@ -162,7 +176,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: matrix.mipsel_softfloat != true
         with:
-          key: ${{ matrix.target }}
+          # Include toolchain in the cache key so a pinned-Rust target
+          # (i686-pc-windows-msvc on 1.77.2) doesn't collide with
+          # stable-Rust caches for other targets, and a future toolchain
+          # bump invalidates only the affected slot.
+          key: ${{ matrix.target }}-${{ matrix.rust_toolchain || 'stable' }}
           cache-bin: "false"
 
       # eframe needs a few system libs on Linux for window management, keyboard,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,12 @@ jobs:
     # mipsel-softfloat is best-effort: the Rust tier-3 target occasionally
     # regresses. Letting it fail keeps the main release going so
     # desktop/Android users aren't blocked by MT7621 router support.
-    continue-on-error: ${{ matrix.mipsel_softfloat == true }}
+    # i686-pc-windows-msvc is similarly best-effort — pinned to Rust
+    # 1.77.2 for Win7 compat (#318), so a future dep MSRV bump above
+    # 1.77 will fail this one target. Letting it skip keeps the rest
+    # of the release unblocked; we'd then choose between dropping the
+    # target or moving to the tier-3 win7-msvc target with build-std.
+    continue-on-error: ${{ matrix.mipsel_softfloat == true || matrix.target == 'i686-pc-windows-msvc' }}
 
     steps:
       # Heal any root-owned leftovers from a previous mipsel docker


### PR DESCRIPTION
## Summary
- Fixes #318: i686 Windows binary fails on Win7 SP1 with `GetSystemTimePreciseAsFile` not found in kernel32.dll
- Rust 1.78+ (May 2024) raised std's Windows MSRV from Win7 to Win10
- Pin only this target to Rust 1.77.2 (last Win7-compatible stable); all other targets stay on `@stable`

## Mechanism
Adds a per-matrix `rust_toolchain` knob. `dtolnay/rust-toolchain@stable` is replaced with `@master` because the per-tag form can't accept a matrix-variable input — `@master` takes the toolchain as a parameter.

Cache key gains a toolchain suffix so the 1.77.2 cache doesn't collide with the stable cache for other targets.

## Test plan
- [ ] CI builds all targets on this PR (verifies the toolchain selector logic doesn't break the matrix)
- [ ] After merge, next release-tag CI run produces `mhrv-rs-windows-i686.zip` built against 1.77.2
- [ ] @Im-P3dro tests v1.7.9 i686 binary on Win7 SP1 — should load without the GetSystemTimePreciseAsFile error
- [ ] Other Windows binaries (windows-amd64) continue to build on stable, unaffected

## Notes
- 1.77.2 is older than mhrv-rs's MSRV-implicitly-tracked-by-stable-CI, so a future dep bump that requires >=1.78 would break the i686 build. If/when that happens, options are:
  1. Drop i686 from the release matrix (the user base is genuinely small)
  2. Switch to the tier-3 `i686-win7-windows-msvc` target with `-Z build-std` (needs nightly)
- For now, mhrv-rs itself uses no >1.77 features, so this should hold for the v1.7.x and v1.8.x cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)