### PR TITLE
fix(android): replace broken clipboard auto-detect with Paste button

### DIFF
--- a/android/app/src/main/java/com/therealaleph/mhrv/ui/ConfigSharing.kt
+++ b/android/app/src/main/java/com/therealaleph/mhrv/ui/ConfigSharing.kt
@@ -63,13 +63,9 @@ fun ConfigSharingBar(
     val clipboard = LocalClipboardManager.current
     val scope = rememberCoroutineScope()
 
-    val clipText = clipboard.getText()?.text.orEmpty()
-    val hasConfigInClipboard = clipText.isNotEmpty() && ConfigStore.looksLikeConfig(clipText)
-
     var showExportDialog by remember { mutableStateOf(false) }
     var showImportConfirm by remember { mutableStateOf(false) }
     var pendingImport by remember { mutableStateOf<MhrvConfig?>(null) }
-    var showQrDialog by remember { mutableStateOf(false) }
 
     // QR scanner launcher — fires the ZXing embedded scanner activity.
     val scanLauncher = rememberLauncherForActivityResult(ScanContract()) { result ->
@@ -83,58 +79,32 @@ fun ConfigSharingBar(
         }
     }
 
-    // --- Paste from clipboard banner ---
-    if (hasConfigInClipboard) {
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-            ),
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 12.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    "Config detected in clipboard",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer,
-                    modifier = Modifier.weight(1f),
-                )
-                FilledTonalButton(
-                    onClick = {
-                        val decoded = ConfigStore.decode(clipText)
-                        if (decoded != null) {
-                            pendingImport = decoded
-                            showImportConfirm = true
-                        } else {
-                            scope.launch { onSnackbar(ctx.getString(R.string.snack_invalid_config)) }
-                        }
-                    },
-                ) {
-                    Icon(Icons.Default.ContentPaste, null, modifier = Modifier.size(18.dp))
-                    Spacer(Modifier.width(4.dp))
-                    Text(stringResource(R.string.btn_import_clipboard))
-                }
-            }
-        }
-    }
-
-    // --- Export + Scan row ---
+    // --- Export + Paste + Scan row ---
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        IconButton(onClick = { showExportDialog = true }) {
+            Icon(Icons.Default.Share, contentDescription = stringResource(R.string.btn_export_config))
+        }
+        // Manual paste — reads clipboard on tap. Android 13+ restricts
+        // background clipboard access, so auto-detect doesn't work.
+        // User interaction (tap) grants clipboard permission.
         OutlinedButton(
-            onClick = { showExportDialog = true },
-            modifier = Modifier.weight(1f),
+            onClick = {
+                val text = clipboard.getText()?.text.orEmpty()
+                val decoded = ConfigStore.decode(text)
+                if (decoded != null) {
+                    pendingImport = decoded
+                    showImportConfirm = true
+                } else {
+                    scope.launch { onSnackbar(ctx.getString(R.string.snack_invalid_config)) }
+                }
+            },
         ) {
-            Icon(Icons.Default.Share, null, modifier = Modifier.size(18.dp))
+            Icon(Icons.Default.ContentPaste, null, modifier = Modifier.size(18.dp))
             Spacer(Modifier.width(4.dp))
-            Text(stringResource(R.string.btn_export_config))
+            Text("Paste")
         }
         OutlinedButton(
             onClick = {


### PR DESCRIPTION
## Bug

The "Config detected in clipboard" banner was intermittently not showing — sometimes it appeared on first app open but never on resume from another app. This made config import via clipboard unreliable.

**Root cause**: Android 13+ restricts `ClipboardManager.getPrimaryClip()` for background-to-foreground transitions. Apps can only read clipboard during active user interaction, not on resume. The auto-detect logic read clipboard during recomposition, which silently returned empty on Android 13+ after switching apps.

## Fix

Replace the unreliable auto-detect banner with a permanent **Paste** button that reads clipboard on tap — user interaction grants clipboard access on all Android versions.

Also: Export button changed to icon-only (share icon) to keep the row compact.

**Before**: `[Export config]  [Scan QR]` + broken auto-detect banner
**After**: `🔗  [Paste]  [Scan QR]`

1 file, 19 insertions, 49 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)