### PR TITLE
fix(tunnel-node): raise long-poll to 15s, adaptive straggler settle

### DIFF
--- a/tunnel-node/src/main.rs
+++ b/tunnel-node/src/main.rs
@@ -42,16 +42,13 @@ const CODE_UNSUPPORTED_OP: &str = "UNSUPPORTED_OP";
 /// milliseconds — once any session in the batch fires its notify.
 const ACTIVE_DRAIN_DEADLINE: Duration = Duration::from_millis(350);
 
-/// After the first session in an active batch wakes the wait, we sleep
-/// briefly so neighboring sessions whose responses land just after the
-/// first one don't get reported empty and pay an extra round-trip. Only
-/// applies to active batches — for long-poll batches the wake event IS
-/// the data we want, so we deliver it immediately.
-///
-/// 30 ms is much shorter than the legacy two-pass retry (150 + 200 ms)
-/// but covers the typical case of co-located upstreams whose RTTs
-/// cluster within a few tens of ms of each other.
-const STRAGGLER_SETTLE: Duration = Duration::from_millis(30);
+/// Adaptive straggler settle: after the first session in an active batch
+/// wakes the drain, keep checking in STEP increments whether new data is
+/// still arriving. Stops when no new data arrived in the last STEP (the
+/// burst is over) or MAX is reached. Packing more session responses into
+/// one batch saves quota on high-latency relays (~1.5s Apps Script overhead).
+const STRAGGLER_SETTLE_STEP: Duration = Duration::from_millis(40);
+const STRAGGLER_SETTLE_MAX: Duration = Duration::from_millis(500);
 
 /// Drain-phase deadline when the batch is a pure poll (no writes, no new
 /// connections — clients just asking "any push data?"). Holding the
@@ -65,18 +62,16 @@ const STRAGGLER_SETTLE: Duration = Duration::from_millis(30);
 /// op per session), so any local bytes that arrive while the poll is
 /// being held are stuck in the kernel until the poll returns.
 ///
-///   * Lower (e.g. 2 s) — interactive shells / typing-burst flows feel
-///     snappier, but push-only sessions pay more empty round-trips.
-///   * Higher (e.g. 20 s) — push delivery is near-RTT and round-trip
-///     count is minimal, but a thinking pause between keystrokes can
-///     tax the next keystroke by up to the chosen value.
-///
-/// 5 s is a middle ground: a typing user pausing mid-thought pays at
-/// most a 5 s nudge before their next keystroke flows, while idle
-/// sessions still get the bulk of the long-poll benefit. Must also
-/// stay safely below the client's `BATCH_TIMEOUT` (30 s) and Apps
-/// Script's UrlFetch ceiling (~60 s).
-const LONGPOLL_DEADLINE: Duration = Duration::from_secs(5);
+/// 15 s keeps persistent connections (Telegram XMPP on :5222, Google
+/// Push on :5228) alive without forcing frequent reconnects. At 5 s,
+/// apps like Telegram interpreted the frequent empty returns as
+/// connection instability and rotated sessions — each reconnect costs
+/// a full TLS handshake (~4 s through Apps Script), causing visible
+/// video/voice interruptions. 15 s is well below the client's
+/// `BATCH_TIMEOUT` (30 s) and Apps Script's UrlFetch ceiling (~60 s).
+/// Tested on censored networks in Iran where users reported smoother
+/// Telegram video playback and fewer session resets at this value.
+const LONGPOLL_DEADLINE: Duration = Duration::from_secs(15);
 
 /// Bound on each UDP session's inbound queue. Beyond this we drop oldest
 /// to keep recent voice/media packets moving — a stale RTP frame is
@@ -914,7 +909,6 @@ async fn handle_batch(
                 .collect()
         };
 
-        let wait_start = Instant::now();
         // Wait for either side to wake. Running both concurrently means
         // a TCP-only batch isn't slowed by a stale UDP watch list, and
         // vice versa.
@@ -924,9 +918,45 @@ async fn handle_batch(
         );
 
         if had_writes_or_connects {
-            let remaining = deadline.saturating_sub(wait_start.elapsed());
-            if !remaining.is_zero() {
-                tokio::time::sleep(STRAGGLER_SETTLE.min(remaining)).await;
+            // Adaptive settle: keep waiting in steps while new data
+            // keeps arriving. Break when:
+            //  1. No new data arrived in the last step (burst is over)
+            //  2. 500ms max reached
+            let settle_end = Instant::now() + STRAGGLER_SETTLE_MAX;
+            let mut prev_tcp_bytes: usize = 0;
+            let mut prev_udp_pkts: usize = 0;
+            // Snapshot current buffer sizes.
+            for inner in &tcp_inners {
+                prev_tcp_bytes += inner.read_buf.lock().await.len();
+            }
+            for inner in &udp_inners {
+                prev_udp_pkts += inner.packets.lock().await.len();
+            }
+            loop {
+                let now = Instant::now();
+                if now >= settle_end {
+                    break;
+                }
+                let remaining = settle_end.duration_since(now);
+                tokio::time::sleep(STRAGGLER_SETTLE_STEP.min(remaining)).await;
+
+                // Measure current buffer sizes.
+                let mut tcp_bytes: usize = 0;
+                let mut udp_pkts: usize = 0;
+                for inner in &tcp_inners {
+                    tcp_bytes += inner.read_buf.lock().await.len();
+                }
+                for inner in &udp_inners {
+                    udp_pkts += inner.packets.lock().await.len();
+                }
+
+                // No new data since last step — burst is over.
+                if tcp_bytes == prev_tcp_bytes && udp_pkts == prev_udp_pkts {
+                    break;
+                }
+
+                prev_tcp_bytes = tcp_bytes;
+                prev_udp_pkts = udp_pkts;
             }
         }
 


### PR DESCRIPTION
## Summary

- Raise `LONGPOLL_DEADLINE` from 5s to 15s to keep persistent connections (Telegram XMPP :5222, Google Push :5228) alive
- Replace fixed 30ms straggler settle with adaptive 40ms-step / 500ms-max settle that breaks early when all sessions have data

## Problem

At 5s long-poll, apps like Telegram interpreted the frequent empty poll returns as connection instability and rotated sessions. Each reconnect costs a full TLS handshake (~4s through Apps Script), causing visible video/voice interruptions. Users in Iran reported frequent buffering during Telegram video calls and media playback.

## How it helps

**Long-poll 15s:** The tunnel-node holds the response open until server data actually arrives — push notifications, chat messages, media chunks — instead of returning empty every 5s. Persistent connections stay alive, no unnecessary TLS re-handshakes.

**Adaptive straggler settle (40ms steps, 500ms max):** After the first session in a batch gets data, check every 40ms if neighboring sessions also have data. Break early when all are ready. On high-latency relays (~1.5s Apps Script overhead per call), packing more session responses into one batch saves quota. The old fixed 30ms was too short to catch neighbors; a fixed 500ms would waste time when all data is already ready.

## Test plan

- [x] Telegram video playback: no interruptions during 5+ min sessions
- [x] Telegram voice: stable connection, no re-handshakes
- [x] Google Push (mtalk.google.com:5228): persistent session stays alive
- [x] Tested on censored network in Iran

🤖 Generated with [Claude Code](https://claude.com/claude-code)