### PR TITLE
feat: listen on all interfaces, hotspot sharing for iOS/laptop

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,26 @@ More deployments = more total concurrency = lower per-session latency. Each batc
 }
 ```
 
+## Sharing via hotspot (Android → iOS / laptop)
+
+The proxy listens on `0.0.0.0` by default, so any device on the same network can use it. This lets you share the tunnel from an Android phone to an iPhone, iPad, or laptop over hotspot:
+
+1. **Android**: enable mobile hotspot + start the app
+2. **Other device**: connect to the Android hotspot WiFi
+3. **Configure proxy** on the other device:
+   - **Server**: `192.168.43.1` (Android's default hotspot IP)
+   - **Port**: `8080` (HTTP) or `1081` (SOCKS5)
+
+### iOS setup
+Settings → WiFi → tap (i) on the hotspot network → Configure Proxy → Manual → Server `192.168.43.1`, Port `8080`.
+
+For full device-wide coverage on iOS, use an app like [Shadowrocket](https://apps.apple.com/app/shadowrocket/id932747118) or [Potatso](https://apps.apple.com/app/potatso/id1239860606) — point it at the SOCKS5 proxy (`192.168.43.1:1081`) and it will route all traffic through the tunnel.
+
+### macOS / Windows
+Set the system HTTP proxy to `192.168.43.1:8080` in network settings, or configure per-app SOCKS5 proxy to `192.168.43.1:1081`.
+
+> **Note**: if `listen_host` is set to `127.0.0.1` in your config, change it to `0.0.0.0` to allow connections from other devices.
+
 ## Running on OpenWRT (or any musl distro)
 
 The `*-linux-musl-*` archives ship a fully static CLI that runs on OpenWRT, Alpine, and any libc-less Linux userland. Put the binary on the router and start it as a service:

--- a/android/app/src/main/java/com/therealaleph/mhrv/ConfigStore.kt
+++ b/android/app/src/main/java/com/therealaleph/mhrv/ConfigStore.kt
@@ -76,7 +76,7 @@ enum class Mode { APPS_SCRIPT, GOOGLE_ONLY, FULL }
 data class MhrvConfig(
     val mode: Mode = Mode.APPS_SCRIPT,
 
-    val listenHost: String = "127.0.0.1",
+    val listenHost: String = "0.0.0.0",
     val listenPort: Int = 8080,
     val socks5Port: Int? = 1081,
 
@@ -395,7 +395,7 @@ object ConfigStore {
                 "full" -> Mode.FULL
                 else -> Mode.APPS_SCRIPT
             },
-            listenHost = obj.optString("listen_host", "127.0.0.1"),
+            listenHost = obj.optString("listen_host", "0.0.0.0"),
             listenPort = obj.optInt("listen_port", 8080),
             socks5Port = obj.optInt("socks5_port", 1081).takeIf { it > 0 },
             appsScriptUrls = urls,

--- a/src/config.rs
+++ b/src/config.rs
@@ -266,7 +266,7 @@ fn default_front_domain() -> String {
     "www.google.com".into()
 }
 fn default_listen_host() -> String {
-    "127.0.0.1".into()
+    "0.0.0.0".into()
 }
 fn default_listen_port() -> u16 {
     8085


### PR DESCRIPTION
Closes #481

## Summary

- Change default `listen_host` from `127.0.0.1` to `0.0.0.0`
- Add "Sharing via hotspot" section to README

## Why

Users often have one Android phone running the tunnel and want to share the connection with an iPhone, iPad, or laptop. With `127.0.0.1` the proxy only accepts local connections. With `0.0.0.0` any device on the hotspot can use it.

## How it works

1. Android phone: enable hotspot + start the app
2. Other device: connect to hotspot WiFi
3. Set proxy to `192.168.43.1:8080` (HTTP) or `:1081` (SOCKS5)

For full device-wide coverage on iOS, use Shadowrocket or Potatso — they create a local VPN that routes all traffic through the SOCKS5 proxy on the Android phone.

## Test plan

- [x] Existing VPN mode still works (tun2proxy binds to the proxy regardless of listen_host)
- [x] Proxy accessible from another device on the same network
- [x] Old configs with explicit `"listen_host": "127.0.0.1"` still honored (not overwritten)

🤖 Generated with [Claude Code](https://claude.com/claude-code)