### PR TITLE
tune: lower coalesce/settle step 40 → 10 ms

### DIFF
--- a/android/app/src/main/java/com/therealaleph/mhrv/ConfigStore.kt
+++ b/android/app/src/main/java/com/therealaleph/mhrv/ConfigStore.kt
@@ -96,7 +96,7 @@ data class MhrvConfig(
     val verifySsl: Boolean = true,
     val logLevel: String = "info",
     val parallelRelay: Int = 1,
-    val coalesceStepMs: Int = 40,
+    val coalesceStepMs: Int = 10,
     val coalesceMaxMs: Int = 1000,
     val upstreamSocks5: String = "",
 
@@ -210,7 +210,7 @@ data class MhrvConfig(
             put("verify_ssl", verifySsl)
             put("log_level", logLevel)
             put("parallel_relay", parallelRelay)
-            if (coalesceStepMs != 40) put("coalesce_step_ms", coalesceStepMs)
+            if (coalesceStepMs != 10) put("coalesce_step_ms", coalesceStepMs)
             if (coalesceMaxMs != 1000) put("coalesce_max_ms", coalesceMaxMs)
             if (upstreamSocks5.isNotBlank()) {
                 put("upstream_socks5", upstreamSocks5.trim())
@@ -422,7 +422,7 @@ object ConfigStore {
             verifySsl = obj.optBoolean("verify_ssl", true),
             logLevel = obj.optString("log_level", "info"),
             parallelRelay = obj.optInt("parallel_relay", 1),
-            coalesceStepMs = obj.optInt("coalesce_step_ms", 40),
+            coalesceStepMs = obj.optInt("coalesce_step_ms", 10),
             coalesceMaxMs = obj.optInt("coalesce_max_ms", 1000),
             upstreamSocks5 = obj.optString("upstream_socks5", ""),
             passthroughHosts = obj.optJSONArray("passthrough_hosts")?.let { arr ->

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,7 +104,7 @@ pub struct Config {
     pub parallel_relay: u8,
     /// Adaptive batch coalesce: after each op arrives, wait this many ms
     /// for more ops before firing the batch. Resets on every arrival.
-    /// 0 = use compiled default (40ms).
+    /// 0 = use compiled default (10ms).
     #[serde(default)]
     pub coalesce_step_ms: u16,
     /// Hard cap on total coalesce wait (ms). 0 = use compiled default (1000ms).

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -518,7 +518,7 @@ impl ProxyServer {
             mitm,
             rewrite_ctx,
             tunnel_mux: None, // initialized in run() inside the tokio runtime
-            coalesce_step_ms: if config.coalesce_step_ms > 0 { config.coalesce_step_ms as u64 } else { 40 },
+            coalesce_step_ms: if config.coalesce_step_ms > 0 { config.coalesce_step_ms as u64 } else { 10 },
             coalesce_max_ms: if config.coalesce_max_ms > 0 { config.coalesce_max_ms as u64 } else { 1000 },
         })
     }

--- a/src/tunnel_client.rs
+++ b/src/tunnel_client.rs
@@ -59,7 +59,18 @@ const CLIENT_FIRST_DATA_WAIT: Duration = Duration::from_millis(50);
 /// Adaptive coalesce defaults: after each new op arrives, wait another
 /// step for more ops. Resets on every arrival, up to max from the first
 /// op. Overridable via config `coalesce_step_ms` / `coalesce_max_ms`.
-const DEFAULT_COALESCE_STEP_MS: u64 = 40;
+///
+/// 10 ms is enough to catch ops that arrive in the same event-loop tick
+/// (e.g. a browser opening 6 parallel connections) without adding
+/// perceptible latency to downloads where the tunnel-node reply — not
+/// coalescing — is the real bottleneck.  When both sides *do* have data
+/// in flight (uploads, bursty page loads), the adaptive reset still
+/// packs batches efficiently: each arriving op resets the step timer, so
+/// a rapid burst naturally coalesces up to `DEFAULT_COALESCE_MAX_MS`
+/// without an explicit upload/download distinction.  The net effect is
+/// "don't wait when there's nothing to wait for; batch aggressively when
+/// there is."
+const DEFAULT_COALESCE_STEP_MS: u64 = 10;
 const DEFAULT_COALESCE_MAX_MS: u64 = 1000;
 
 /// Structured error code the tunnel-node returns when it doesn't know the

--- a/tunnel-node/src/main.rs
+++ b/tunnel-node/src/main.rs
@@ -47,8 +47,8 @@ const ACTIVE_DRAIN_DEADLINE: Duration = Duration::from_millis(350);
 /// still arriving. Stops when no new data arrived in the last STEP (the
 /// burst is over) or MAX is reached. Packing more session responses into
 /// one batch saves quota on high-latency relays (~1.5s Apps Script overhead).
-const STRAGGLER_SETTLE_STEP: Duration = Duration::from_millis(40);
-const STRAGGLER_SETTLE_MAX: Duration = Duration::from_millis(500);
+const STRAGGLER_SETTLE_STEP: Duration = Duration::from_millis(10);
+const STRAGGLER_SETTLE_MAX: Duration = Duration::from_millis(1000);
 
 /// Drain-phase deadline when the batch is a pure poll (no writes, no new
 /// connections — clients just asking "any push data?"). Holding the


### PR DESCRIPTION
## Summary

Lower the adaptive coalesce step (client) and straggler settle step (tunnel-node) from 40 ms to 10 ms. Raise the tunnel-node settle max from 500 ms to 1000 ms.

## Rationale

The batch pipeline has two phases where data can accumulate:

1. **Client coalesce** — ops queue up before firing a batch to Apps Script
2. **Tunnel-node settle** — upstream TCP replies trickle in before the batch response is sent back

The 40 ms step was conservative: it gave each phase a wide window to pack more data per batch, saving Apps Script round-trips. But this window is **wasted on downloads** — when the client is just waiting for data and has nothing new to send, each 40 ms step is pure dead air before the batch fires.

**The fix is asymmetric by design:**

- **Step: 40 → 10 ms** — When there's nothing else to pack, fire almost immediately. The 10 ms still catches ops that land in the same event-loop tick (e.g. a browser opening 6 parallel connections on page load), so we don't degenerate into single-op batches on a burst.

- **Max (client): stays at 1000 ms** — When both sides *do* have data (uploads, bursty page loads), the adaptive reset keeps packing: each arriving op resets the 10 ms step timer, so a rapid burst naturally coalesces up to the 1 s cap. This saves quota by packing many ops into fewer round-trips.

- **Settle max (tunnel-node): 500 → 1000 ms** — More room to pack straggler upstream replies when targets respond at different speeds. One slow CDN shouldn't force a premature flush that wastes a whole Apps Script call for the late reply.

**In short: don't wait when there's nothing to wait for; batch aggressively when there is.**

## Changes

| Component | Setting | Old | New |
|---|---|---|---|
| Client | `coalesce_step_ms` | 40 ms | **10 ms** |
| Client | `coalesce_max_ms` | 1000 ms | 1000 ms (unchanged) |
| Tunnel-node | `STRAGGLER_SETTLE_STEP` | 40 ms | **10 ms** |
| Tunnel-node | `STRAGGLER_SETTLE_MAX` | 500 ms | **1000 ms** |

## Backwards compatibility

Users with `"coalesce_step_ms": 40` in config.json keep the old behaviour — the compiled default only applies when the field is absent or 0.

## Test plan
- [ ] Full tunnel: load a heavy page, confirm downloads feel snappier (~30 ms less per batch)
- [ ] Upload a large file via full tunnel, check logs for batch sizes (should still coalesce well)
- [ ] Long-running session (Telegram, WebSocket), verify no regressions in push latency
- [ ] Android: fresh install picks up 10 ms default; existing config with explicit 40 is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)