### PR TITLE
Update config.fronting-groups.example.json

### DIFF
--- a/config.fronting-groups.example.json
+++ b/config.fronting-groups.example.json
@@ -29,14 +29,46 @@
       "ip": "151.101.1.140",
       "sni": "www.python.org",
       "domains": [
+        "redd.it",
         "reddit.com",
         "redditstatic.com",
         "redditmedia.com",
-        "redd.it",
+        "reddit.app.link",
+        "redditblog.com",
+        "reddithelp.com",
+        "redditinc.com",
+        "redditmail.com",
+        "redditspace.com",
+        "redditstatus.com",
+        "reddit.map.fastly.net",
+
         "githubassets.com",
         "githubusercontent.com",
+
         "pypi.org",
-        "fastly.com"
+
+        "fastly.com",
+        "fastly-edge.com",
+        "fastly-terrarium.com",
+        "fastly.io",
+        "fastly.net",
+        "fastlylabs.com",
+        "fastlylb.net",
+
+        "www.pinterest.com",
+        "pinimg.com",
+        
+        "cnn.com",
+        "cnn.io",
+        "cnn.it",
+        "cnnarabic.com",
+        "cnnlabs.com",
+        "cnnmoney.ch",
+        "cnnmoney.com",
+        "cnnmoneystream.com",
+        "cnnpolitics.com",
+
+        "buzzfeed.com"
       ]
     },
     {


### PR DESCRIPTION
Added more Fastly fronting groups

I've added more Fastly domains that can be used in domain-fronting including Pinterset, CNN, Reddit, etc.
Most of them where introduced in [this commit](https://github.com/patterniha/MITM-DomainFronting/commit/3e339ee33003689f05c2994e78ecb4d0972bda29) and in the [original file](https://github.com/patterniha/MITM-DomainFronting/blob/3e339ee33003689f05c2994e78ecb4d0972bda29/Xray-config/MITM-DomainFronting.json)

All the credits goes to @patterniha