### PR TITLE
feat: block QUIC by default — faster initial page/video loads in full tunnel mode

### DIFF
--- a/android/app/src/main/java/com/therealaleph/mhrv/ConfigStore.kt
+++ b/android/app/src/main/java/com/therealaleph/mhrv/ConfigStore.kt
@@ -98,6 +98,8 @@ data class MhrvConfig(
     val parallelRelay: Int = 1,
     val coalesceStepMs: Int = 10,
     val coalesceMaxMs: Int = 1000,
+    /** Block QUIC (UDP/443). QUIC over TCP tunnel causes meltdown. */
+    val blockQuic: Boolean = true,
     val upstreamSocks5: String = "",
 
     /**
@@ -219,6 +221,7 @@ data class MhrvConfig(
             put("parallel_relay", parallelRelay)
             if (coalesceStepMs != 10) put("coalesce_step_ms", coalesceStepMs)
             if (coalesceMaxMs != 1000) put("coalesce_max_ms", coalesceMaxMs)
+            put("block_quic", blockQuic)
             if (upstreamSocks5.isNotBlank()) {
                 put("upstream_socks5", upstreamSocks5.trim())
             }
@@ -330,6 +333,7 @@ object ConfigStore {
         if (cfg.parallelRelay != defaults.parallelRelay) obj.put("parallel_relay", cfg.parallelRelay)
         if (cfg.coalesceStepMs != defaults.coalesceStepMs) obj.put("coalesce_step_ms", cfg.coalesceStepMs)
         if (cfg.coalesceMaxMs != defaults.coalesceMaxMs) obj.put("coalesce_max_ms", cfg.coalesceMaxMs)
+        if (cfg.blockQuic != defaults.blockQuic) obj.put("block_quic", cfg.blockQuic)
         if (cfg.upstreamSocks5.isNotBlank()) obj.put("upstream_socks5", cfg.upstreamSocks5)
         if (cfg.passthroughHosts.isNotEmpty()) obj.put("passthrough_hosts", JSONArray().apply { cfg.passthroughHosts.forEach { put(it) } })
         if (cfg.tunnelDoh != defaults.tunnelDoh) obj.put("tunnel_doh", cfg.tunnelDoh)
@@ -433,6 +437,7 @@ object ConfigStore {
             parallelRelay = obj.optInt("parallel_relay", 1),
             coalesceStepMs = obj.optInt("coalesce_step_ms", 10),
             coalesceMaxMs = obj.optInt("coalesce_max_ms", 1000),
+            blockQuic = obj.optBoolean("block_quic", true),
             upstreamSocks5 = obj.optString("upstream_socks5", ""),
             passthroughHosts = obj.optJSONArray("passthrough_hosts")?.let { arr ->
                 buildList { for (i in 0 until arr.length()) add(arr.optString(i)) }

--- a/android/app/src/main/java/com/therealaleph/mhrv/ui/HomeScreen.kt
+++ b/android/app/src/main/java/com/therealaleph/mhrv/ui/HomeScreen.kt
@@ -1265,6 +1265,28 @@ private fun AdvancedSettings(
             )
         }
 
+        // Block QUIC toggle
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    "Block QUIC",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    "Drop UDP/443 so browsers use TCP/HTTPS. QUIC over TCP tunnel causes meltdown.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = cfg.blockQuic,
+                onCheckedChange = { onChange(cfg.copy(blockQuic = it)) },
+            )
+        }
+
         // Block DoH toggle
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/src/bin/ui.rs
+++ b/src/bin/ui.rs
@@ -420,7 +420,7 @@ fn load_form() -> (FormState, Option<String>) {
             normalize_x_graphql: false,
             youtube_via_relay: false,
             passthrough_hosts: Vec::new(),
-            block_quic: false,
+            block_quic: true,
             disable_padding: false,
             tunnel_doh: true,
             bypass_doh_hosts: Vec::new(),
@@ -1238,6 +1238,16 @@ impl eframe::App for App {
                              prompts. Enable this to route youtube.com / youtu.be / ytimg.com through the Apps \
                              Script relay instead — slower for video, but the visible SNI matches the site.",
                         );
+                    });
+                    ui.horizontal(|ui| {
+                        ui.add_space(120.0 + 8.0);
+                        ui.checkbox(&mut self.form.block_quic, "Block QUIC (UDP/443)")
+                            .on_hover_text(
+                                "Drop QUIC (UDP port 443) so browsers fall back to TCP/HTTPS. \
+                                 QUIC over the TCP-based tunnel causes TCP-over-TCP meltdown \
+                                 (<1 Mbps). Browsers detect the drop and switch to TCP within seconds. \
+                                 Issue #213, #793.",
+                            );
                     });
                 });
             });

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,7 +202,7 @@ pub struct Config {
     /// flag lets users who care about consistency over peak speed
     /// opt out of QUIC at the source rather than discovering its
     /// failure modes later. Issue #213.
-    #[serde(default)]
+    #[serde(default = "default_block_quic")]
     pub block_quic: bool,
     /// When true, suppress the random `_pad` field that v1.8.0+ adds
     /// to outbound Apps Script requests for DPI evasion. Default off
@@ -480,6 +480,11 @@ fn default_google_ip_validation() -> bool {true}
 /// dominant userbase. Users on networks where direct DoH works can
 /// opt back in with `tunnel_doh: false`.
 fn default_tunnel_doh() -> bool { true }
+
+/// Default for `block_quic`: `true`. QUIC over the TCP-based tunnel
+/// causes TCP-over-TCP meltdown (<1 Mbps). Browsers fall back to
+/// HTTPS/TCP within seconds of the silent UDP drop. Issue #793.
+fn default_block_quic() -> bool { true }
 
 /// Default for `block_doh`: `true` (browser DoH is rejected so the
 /// browser falls back to system DNS, which `tun2proxy` resolves


### PR DESCRIPTION
## Summary

- **Default `block_quic` to `true`** (was `false`). QUIC over the TCP-based tunnel causes TCP-over-TCP meltdown (<1 Mbps). Browsers detect the silent UDP/443 drop and fall back to TCP/HTTPS within seconds — significantly improving initial page and YouTube video load times in full tunnel mode.
- **Android UI**: "Block QUIC" toggle in Advanced settings.
- **Desktop UI**: "Block QUIC (UDP/443)" checkbox (was config-only since #213).
- **Android serialization**: always emit `block_quic` to JSON so the Rust default can't silently override the user's choice.

## Why this matters for full tunnel mode

Without `block_quic`, browsers attempt QUIC (HTTP/3) first on every new connection. In full tunnel mode, QUIC datagrams travel over the TCP-based tunnel — TCP-over-TCP meltdown caps throughput at <1 Mbps. The browser eventually falls back to TCP/HTTPS, but only after wasting 5-10s on failed QUIC attempts. This is most visible as:
- **YouTube**: initial video delay while the player waits for QUIC to fail before switching to TCP
- **Heavy pages**: extra seconds per domain as each QUIC attempt times out

With `block_quic: true`, the UDP/443 packets are silently dropped, the browser detects this in ~1-2s and goes straight to TCP/HTTPS — no meltdown, no wasted time.

Closes #793.

## Test plan

- [x] `cargo check` clean
- [x] Block QUIC checkbox in desktop UI with hover tooltip
- [x] Block QUIC toggle in Android Advanced UI
- [x] Android emits `block_quic` in JSON config
- [x] Rust default `true` via `default_block_quic()`
- [x] Tested on Pixel 6 Pro — YouTube and page loads noticeably faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)