### PR TITLE
fix: v1.9.15 full-mode warm-up race during h2 init (#924)

### DIFF
--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -131,6 +131,14 @@ const H2_OPEN_TIMEOUT_SECS: u64 = 8;
 /// long. Prevents every concurrent caller during an h2 outage from
 /// paying its own full handshake-timeout cost in turn.
 const H2_OPEN_FAILURE_BACKOFF_SECS: u64 = 15;
+/// Same idea as `H2_OPEN_TIMEOUT_SECS` but for the legacy h1 socket
+/// path. Without this, a stuck TCP connect or TLS handshake to a
+/// blackholed `connect_host:443` would block `acquire()` (and the
+/// `warm()` prewarm loop) until the outer batch budget elapsed —
+/// the same symptom #924 hit during the warm-race window. Bounded
+/// here so a single hung handshake aborts fast and the loop / caller
+/// makes progress on the next attempt.
+const H1_OPEN_TIMEOUT_SECS: u64 = 8;
 /// Cadence for Apps Script container keepalive pings. Apps Script
 /// containers go cold after ~5min idle and cost 1-3s on the first
 /// request to wake back up — most painful on YouTube / streaming where
@@ -156,10 +164,23 @@ struct PoolEntry {
 /// `generation` is monotonic per fronter and lets `poison_h2_if_gen`
 /// avoid the race where task A's stale failure clears task B's
 /// freshly-reopened healthy cell.
+///
+/// `dead` is set by the spawned connection-driver task when the h2
+/// `Connection` future ends (GOAWAY, network error, normal close).
+/// Without this, the cell silently held a dead `SendRequest` after a
+/// mid-session disconnect — the next request paid a wasted h2 round
+/// trip to detect it via `ready()` failure, AND `run_pool_refill`
+/// kept maintaining the small `POOL_MIN_H2_FALLBACK` (2-socket) pool
+/// instead of expanding to `POOL_MIN` (8). With the flag,
+/// `run_pool_refill` notices h2 is dead within one tick (≤5 s) and
+/// pre-warms the larger fallback pool before the next request burst,
+/// and `ensure_h2` short-circuits the `H2_CONN_TTL_SECS`-based
+/// liveness check on a known-dead cell.
 struct H2Cell {
     send: h2::client::SendRequest<Bytes>,
     created: Instant,
     generation: u64,
+    dead: Arc<AtomicBool>,
 }
 
 /// "Did this request reach Apps Script?" signal carried out of every
@@ -864,17 +885,27 @@ impl DomainFronter {
     }
 
     async fn open(&self) -> Result<PooledStream, FronterError> {
-        let tcp = TcpStream::connect((self.connect_host.as_str(), 443u16)).await?;
-        let _ = tcp.set_nodelay(true);
-        let sni = self.next_sni();
-        let name = ServerName::try_from(sni)?;
-        // Always use the h1-only connector here — the pool only holds
-        // sockets that the raw HTTP/1.1 fallback path can write to.
-        // Using the shared connector would let some pooled sockets
-        // negotiate h2, which would then misframe every fallback
-        // request that lands on them.
-        let tls = self.tls_connector_h1.connect(name, tcp).await?;
-        Ok(tls)
+        // Bounded TCP+TLS open. See `H1_OPEN_TIMEOUT_SECS`.
+        let work = async {
+            let tcp = TcpStream::connect((self.connect_host.as_str(), 443u16)).await?;
+            let _ = tcp.set_nodelay(true);
+            let sni = self.next_sni();
+            let name = ServerName::try_from(sni)?;
+            // Always use the h1-only connector here — the pool only holds
+            // sockets that the raw HTTP/1.1 fallback path can write to.
+            // Using the shared connector would let some pooled sockets
+            // negotiate h2, which would then misframe every fallback
+            // request that lands on them.
+            let tls = self.tls_connector_h1.connect(name, tcp).await?;
+            Ok::<_, FronterError>(tls)
+        };
+        match tokio::time::timeout(Duration::from_secs(H1_OPEN_TIMEOUT_SECS), work).await {
+            Ok(r) => r,
+            Err(_) => Err(FronterError::Relay(format!(
+                "h1 open timed out after {}s",
+                H1_OPEN_TIMEOUT_SECS
+            ))),
+        }
     }
 
     /// Open outbound TLS connections eagerly so the first relay request
@@ -982,7 +1013,10 @@ impl DomainFronter {
                 let cell = self.h2_cell.lock().await;
                 let h2_alive = cell
                     .as_ref()
-                    .map(|c| c.created.elapsed().as_secs() < H2_CONN_TTL_SECS)
+                    .map(|c| {
+                        c.created.elapsed().as_secs() < H2_CONN_TTL_SECS
+                            && !c.dead.load(Ordering::Relaxed)
+                    })
                     .unwrap_or(false);
                 if h2_alive { POOL_MIN_H2_FALLBACK } else { POOL_MIN }
             };
@@ -1127,16 +1161,18 @@ impl DomainFronter {
             return None;
         }
 
-        // Fast path: existing cell, within TTL. Clone (Arc bump) and
-        // return without touching the open machinery. We can't peek at
-        // SendRequest liveness directly (h2 0.4 doesn't expose
-        // `is_closed`), so a request against a dead conn fails at
-        // `ready()`/`send_request` and the caller poisons by
-        // generation from there.
+        // Fast path: existing cell, within TTL and not flagged dead by
+        // the connection driver. We can't peek at SendRequest liveness
+        // synchronously (h2 0.4 doesn't expose `is_closed`), but the
+        // driver task does flip `dead` when the underlying connection
+        // ends — so a known-dead cell is rejected here without paying
+        // a wasted h2 round trip to discover it.
         {
             let cell = self.h2_cell.lock().await;
             if let Some(c) = cell.as_ref() {
-                if c.created.elapsed().as_secs() < H2_CONN_TTL_SECS {
+                if c.created.elapsed().as_secs() < H2_CONN_TTL_SECS
+                    && !c.dead.load(Ordering::Relaxed)
+                {
                     return Some((c.send.clone(), c.generation));
                 }
             }
@@ -1167,7 +1203,9 @@ impl DomainFronter {
         {
             let cell = self.h2_cell.lock().await;
             if let Some(c) = cell.as_ref() {
-                if c.created.elapsed().as_secs() < H2_CONN_TTL_SECS {
+                if c.created.elapsed().as_secs() < H2_CONN_TTL_SECS
+                    && !c.dead.load(Ordering::Relaxed)
+                {
                     return Some((c.send.clone(), c.generation));
                 }
             }
@@ -1180,8 +1218,8 @@ impl DomainFronter {
             tokio::time::timeout(Duration::from_secs(H2_OPEN_TIMEOUT_SECS), self.open_h2())
                 .await;
 
-        let send = match open_result {
-            Ok(Ok(s)) => s,
+        let (send, dead) = match open_result {
+            Ok(Ok(pair)) => pair,
             Ok(Err(OpenH2Error::AlpnRefused)) => {
                 // Definitive: this peer doesn't speak h2. Sticky-disable
                 // so we never re-attempt the handshake.
@@ -1218,6 +1256,7 @@ impl DomainFronter {
             send: send.clone(),
             created: Instant::now(),
             generation,
+            dead,
         });
         Some((send, generation))
     }
@@ -1225,7 +1264,11 @@ impl DomainFronter {
     /// Open one TLS connection and run the h2 handshake. Returns a
     /// typed `OpenH2Error` so the caller can recognize ALPN refusal
     /// (sticky disable) without string-matching across boundaries.
-    async fn open_h2(&self) -> Result<h2::client::SendRequest<Bytes>, OpenH2Error> {
+    /// The returned `Arc<AtomicBool>` is the death flag the connection
+    /// driver flips when the h2 `Connection` future ends.
+    async fn open_h2(
+        &self,
+    ) -> Result<(h2::client::SendRequest<Bytes>, Arc<AtomicBool>), OpenH2Error> {
         let tcp = TcpStream::connect((self.connect_host.as_str(), 443u16)).await?;
         let _ = tcp.set_nodelay(true);
         let sni = self.next_sni();
@@ -1240,7 +1283,7 @@ impl DomainFronter {
     /// bypassing the hard-coded `connect_host:443` target.
     async fn h2_handshake_post_tls(
         tls: PooledStream,
-    ) -> Result<h2::client::SendRequest<Bytes>, OpenH2Error> {
+    ) -> Result<(h2::client::SendRequest<Bytes>, Arc<AtomicBool>), OpenH2Error> {
         let alpn_h2 = tls
             .get_ref()
             .1
@@ -1263,15 +1306,19 @@ impl DomainFronter {
             .map_err(|e| OpenH2Error::Handshake(e.to_string()))?;
         // The connection task drives frame I/O independently of any
         // SendRequest handle. When it ends (GOAWAY, network error, TTL),
-        // existing handles will start failing on `ready()` / `send_request`
-        // and `ensure_h2` will reopen on the next call.
+        // we flip the `dead` flag so `ensure_h2` and `run_pool_refill`
+        // can react within one refill tick instead of waiting for a
+        // request to discover the breakage via `ready()` failure.
+        let dead = Arc::new(AtomicBool::new(false));
+        let dead_for_driver = dead.clone();
         tokio::spawn(async move {
             if let Err(e) = conn.await {
                 tracing::debug!("h2 connection closed: {}", e);
             }
+            dead_for_driver.store(true, Ordering::Relaxed);
         });
         tracing::info!("h2 connection established to relay edge");
-        Ok(send)
+        Ok((send, dead))
     }
 
     /// React to an h2-fronting-incompatibility HTTP response (status
@@ -5132,6 +5179,7 @@ hello";
                 send: send_v2.clone(),
                 created: Instant::now(),
                 generation: 2,
+                dead: Arc::new(AtomicBool::new(false)),
             });
         }
         // Task A poisons with stale gen=1.
@@ -5149,6 +5197,54 @@ hello";
         fronter.poison_h2_if_gen(2).await;
         let cell = fronter.h2_cell.lock().await;
         assert!(cell.is_none(), "poison_h2_if_gen(2) must clear gen=2 cell");
+
+        server_handle.abort();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ensure_h2_rejects_dead_cell_within_ttl() {
+        // Cell is within H2_CONN_TTL_SECS but the connection driver
+        // already flipped `dead` (e.g., upstream sent GOAWAY). Without
+        // the dead-flag check `ensure_h2` would happily hand out the
+        // stale SendRequest and the next request would pay a wasted
+        // h2 round trip to discover the breakage. With the check in
+        // place a second pre-existing healthy cell still works fine —
+        // the dead one is replaced via the open-lock path.
+        let (addr, server_handle) = spawn_h2c_server(|_req| {
+            let resp = http::Response::builder().status(200).body(()).unwrap();
+            (resp, Vec::new())
+        })
+        .await;
+        let send = h2c_client(addr).await;
+
+        let fronter = fronter_for_test(false);
+        let dead = Arc::new(AtomicBool::new(true)); // simulate driver having exited
+        {
+            let mut cell = fronter.h2_cell.lock().await;
+            *cell = Some(H2Cell {
+                send,
+                created: Instant::now(), // well within TTL
+                generation: 1,
+                dead: dead.clone(),
+            });
+        }
+
+        // The fast path normally returns Some(send, gen) when the cell
+        // is within TTL. With dead=true it must NOT return the stale
+        // SendRequest. We can't drive the open machinery here (no real
+        // Google edge), so the test asserts "doesn't return the stale
+        // cell" rather than "successfully reopens".
+        //
+        // ensure_h2 will fall through to the open path which will
+        // eventually try to TCP-connect to `connect_host:443`. That's
+        // a fake address in `fronter_for_test`, so the open will fail
+        // — and ensure_h2 returns None. The point is: the stale gen=1
+        // SendRequest was NOT served.
+        let result = fronter.ensure_h2().await;
+        assert!(
+            result.is_none(),
+            "ensure_h2 must not serve a cell whose driver flipped `dead`"
+        );
 
         server_handle.abort();
     }
@@ -5578,6 +5674,7 @@ hello";
                 send: send.clone(),
                 created: Instant::now(),
                 generation: 7,
+                dead: Arc::new(AtomicBool::new(false)),
             });
         }
         // Pretend a round-trip just incremented h2_calls (which is
@@ -5694,7 +5791,7 @@ hello";
         match result {
             Err(OpenH2Error::AlpnRefused) => {} // expected
             Err(other) => panic!("expected AlpnRefused, got {:?}", other),
-            Ok(_) => panic!("expected AlpnRefused, got Ok"),
+            Ok((_send, _dead)) => panic!("expected AlpnRefused, got Ok"),
         }
         server.await.unwrap();
     }

--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -920,11 +920,13 @@ impl DomainFronter {
     /// prewarm behind `ensure_h2()` so the h1 pool stayed empty during
     /// the h2 init window.
     ///
-    /// Staggered 500 ms apart so we don't burst N TLS handshakes at the
-    /// Google edge simultaneously, and each connection gets an 8 s
-    /// expiry offset so they roll off gradually instead of all hitting
-    /// POOL_TTL_SECS at once. If h2 ends up the active fast path,
-    /// `run_pool_refill` trims the pool back down to
+    /// The spawned h2 handshake races h1[0] — boot fires two TLS
+    /// handshakes back-to-back. The 500 ms stagger only applies between
+    /// h1[i] and h1[i+1] for i ≥ 1, so we don't burst the remaining
+    /// h1[1..n] handshakes at the Google edge simultaneously. Each
+    /// connection gets an 8 s expiry offset so they roll off gradually
+    /// instead of all hitting POOL_TTL_SECS at once. If h2 ends up the
+    /// active fast path, `run_pool_refill` trims the pool back down to
     /// `POOL_MIN_H2_FALLBACK` on the next tick — the extra warm h1
     /// sockets just age out naturally instead of being kept alive.
     pub async fn warm(self: &Arc<Self>, n: usize) {
@@ -961,10 +963,16 @@ impl DomainFronter {
             }
         }
         // Join the h2 prewarm here only to log whether it landed; the
-        // h1 pool above is already populated either way. JoinError
-        // collapses to "h2 not alive" — same as if ensure_h2 returned
-        // None — so we still log a useful line.
-        let h2_alive = h2_handle.await.unwrap_or(false);
+        // h1 pool above is already populated either way. A panic in
+        // the spawned task surfaces as `JoinError` — log it explicitly
+        // so it isn't indistinguishable from a clean ALPN refusal.
+        let h2_alive = match h2_handle.await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("h2 prewarm task failed to join: {}", e);
+                false
+            }
+        };
         if h2_alive {
             tracing::info!(
                 "h2 fast path active; h1 fallback pool pre-warmed with {} connection(s)",
@@ -5231,15 +5239,13 @@ hello";
 
         // The fast path normally returns Some(send, gen) when the cell
         // is within TTL. With dead=true it must NOT return the stale
-        // SendRequest. We can't drive the open machinery here (no real
-        // Google edge), so the test asserts "doesn't return the stale
-        // cell" rather than "successfully reopens".
-        //
-        // ensure_h2 will fall through to the open path which will
-        // eventually try to TCP-connect to `connect_host:443`. That's
-        // a fake address in `fronter_for_test`, so the open will fail
-        // — and ensure_h2 returns None. The point is: the stale gen=1
-        // SendRequest was NOT served.
+        // SendRequest. Pre-set the failure-backoff timestamp so
+        // ensure_h2 short-circuits at the backoff check (no network
+        // I/O) regardless of whatever's bound on 127.0.0.1:443 on the
+        // dev/CI host. This isolates the assertion to the new
+        // dead-flag check.
+        *fronter.h2_open_failed_at.lock().await = Some(Instant::now());
+
         let result = fronter.ensure_h2().await;
         assert!(
             result.is_none(),

--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -880,28 +880,35 @@ impl DomainFronter {
     /// Open outbound TLS connections eagerly so the first relay request
     /// doesn't pay a cold handshake.
     ///
-    /// When h2 is enabled, attempts to open the multiplexed h2 cell
-    /// first. Success there means one TCP/TLS handshake serves all
-    /// future requests, so we only need a tiny fallback h1 pool
-    /// (clamped to 2) instead of the full `n` requested. On h2 failure
-    /// (ALPN refusal, network error), falls back to the legacy
-    /// behavior: warm the full `n` h1 sockets.
+    /// h2 and h1 prewarm run in parallel: a request that arrives while
+    /// the h2 handshake is still in flight (or has just hit its 8 s
+    /// timeout) needs a warm h1 socket waiting for it, otherwise the
+    /// h1 fallback path pays a cold handshake on the same slow network
+    /// and the 30 s outer batch budget elapses (#924). v1.9.14 warmed
+    /// h1 unconditionally; v1.9.15 (PR #799) accidentally gated the h1
+    /// prewarm behind `ensure_h2()` so the h1 pool stayed empty during
+    /// the h2 init window.
     ///
     /// Staggered 500 ms apart so we don't burst N TLS handshakes at the
     /// Google edge simultaneously, and each connection gets an 8 s
     /// expiry offset so they roll off gradually instead of all hitting
-    /// POOL_TTL_SECS at once.
+    /// POOL_TTL_SECS at once. If h2 ends up the active fast path,
+    /// `run_pool_refill` trims the pool back down to
+    /// `POOL_MIN_H2_FALLBACK` on the next tick — the extra warm h1
+    /// sockets just age out naturally instead of being kept alive.
     pub async fn warm(self: &Arc<Self>, n: usize) {
-        // Try to bring up the h2 fast path first. If that succeeds,
-        // shrink the h1 pool warm count to the fallback minimum — the
-        // multiplexed h2 conn handles all real traffic, so the h1 pool
-        // only needs to cover the rare case where h2 dies mid-session.
-        let h2_alive = !self.h2_disabled.load(Ordering::Relaxed)
-            && self.ensure_h2().await.is_some();
-        let h1_target = if h2_alive { 2.min(n) } else { n };
+        // Spawn the h2 prewarm in parallel so the h1 prewarm loop
+        // below isn't blocked on it. Capturing the join handle lets
+        // us still log "h2 fast path active" / "h1 fallback only"
+        // accurately at the end.
+        let h2_self = self.clone();
+        let h2_handle = tokio::spawn(async move {
+            !h2_self.h2_disabled.load(Ordering::Relaxed)
+                && h2_self.ensure_h2().await.is_some()
+        });
 
         let mut warmed = 0usize;
-        for i in 0..h1_target {
+        for i in 0..n {
             if i > 0 {
                 tokio::time::sleep(Duration::from_millis(500)).await;
             }
@@ -922,6 +929,11 @@ impl DomainFronter {
                 }
             }
         }
+        // Join the h2 prewarm here only to log whether it landed; the
+        // h1 pool above is already populated either way. JoinError
+        // collapses to "h2 not alive" — same as if ensure_h2 returned
+        // None — so we still log a useful line.
+        let h2_alive = h2_handle.await.unwrap_or(false);
         if h2_alive {
             tracing::info!(
                 "h2 fast path active; h1 fallback pool pre-warmed with {} connection(s)",


### PR DESCRIPTION
## Summary

Fixes #924, the canonical tracking thread for an 18+ duplicate cluster of "Full-tunnel mode broken since v1.9.15" reports.

**What affected users see:**

- `batch timed out after 30s` and `tunnel connect_data error … batch timed out` in mhrv-rs logs
- `curl: (28) SSL connection timeout` against `127.0.0.1:8086` (the SOCKS5 listener)
- Apps-Script mode keeps working — narrows the regression to the Full-mode data plane: SOCKS5 → domain-fronted relay → Apps Script → tunnel-node → internet
- Only available workaround: the `"force_http1": true` kill switch added by PR #799 itself

**Root cause:**

Bisect (see below) lands on PR #799, which added HTTP/2 multiplexing on the relay leg. That change is correct in steady state — one multiplexed TCP/TLS socket replacing the legacy 8–80-socket pool fixes the head-of-line blocking that #781/#773 were filed for. The bug is one line of startup ordering inside `warm()`:

- **v1.9.14:** prewarmed the h1 socket pool unconditionally — by the time the user's first request arrived, 6–16 sockets were ready
- **v1.9.15 (PR #799):** gated the h1 prewarm loop behind `ensure_h2().await` — `ensure_h2()` is bounded by `H2_OPEN_TIMEOUT_SECS` (8 s) but can take the full 8 s on a cold first connection, and during that window the h1 pool is empty

**Fallout chain when a request arrives in the warm-up window:**

1. `ensure_h2()` is still holding `h2_open_lock` (or has yet to populate the cell) — request gets `Err((Relay("h2 unavailable"), No))` immediately and falls back to h1
2. h1 path calls `acquire()` → empty pool → `open()` → fresh TCP+TLS to `connect_host:443`
3. Same network conditions that stalled the h2 handshake also stall the h1 handshake; cold open exceeds the 30 s `batch_timeout` enforced in `tunnel_client.rs::dispatch_full_tunnel`
4. Handshake never gets to send the POST → tunnel-node never sees the request → user sees a 30 s timeout that "works on apps_script mode" can't explain

**This PR:**

- Restores v1.9.14 ordering — h1 prewarm runs in parallel with the h2 handshake instead of after it
- Fallback pool is ready whether or not h2 succeeds
- h2 fast path is unchanged; multiplexing still wins in steady state
- `run_pool_refill` trims the h1 pool back to `POOL_MIN_H2_FALLBACK` (2) once h2 lands
- Two commits: the first is the race fix; the second adds bounded timeouts on `open()` and synchronous detection of mid-session h2 deaths, closing two adjacent paths where the same stall pattern could recur

## Bisect

Bisected `git log v1.9.14..v1.9.15` (4 commits, 2 functional). The kill switch added by PR #799 itself made it possible to confirm the SHA at runtime instead of running a full `git bisect run`:

| Build | Probe result |
|---|---|
| `v1.9.14` baseline | ✅ 200 OK in 17.9 s |
| `v1.9.15` default (h2 enabled) | ❌ `curl: (28) SSL connection timeout` after 12 s |
| `v1.9.15` + `"force_http1": true` | ✅ 200 OK in 17.7 s |

Bisected commit: `0e678630a8bde9ccb02b9d40dd2de4bc65bdfbf4` ("HTTP/2 multiplexing on relay leg with idempotency-safe h1 fallback", PR #799).

## Symptoms

Unique log lines on the failing default-`v1.9.15` run (`comm -23 bad good`):

```
DEBUG h2 batch request pre-send failure: relay error: h2 unavailable — falling back to h1
DEBUG h2 open timed out after 8s — falling back to h1
WARN  batch timed out after 30s (script AKfycbwj…, 1 ops)
ERROR tunnel connect_data error for api.ipify.org:443: batch timed out
```

- h1 fallback also fails on default v1.9.15
- Manual `curl` to the same Apps Script deployment with the same `AUTH_KEY` cleanly drives a tunnel-node session
- The h1 path itself is fine; it's just empty when it's needed

## Changes

### Commit 1: `fix: warm h1 pool in parallel with h2 (#924)`

- Spawn the h2 prewarm in a separate task so the h1 prewarm loop runs concurrently
- Full `n` h1 sockets (6–16 depending on `num_scripts.clamp`) are warm before user traffic, even when the h2 handshake is slow or hits its 8 s timeout
- **Trade-off:** extra TLS handshakes at startup
  - `run_pool_refill` trims the pool back to `POOL_MIN_H2_FALLBACK` (2) within 5 s when h2 ends up the active fast path
  - Surplus h1 sockets age out via `POOL_TTL_SECS` rather than being kept alive

### Commit 2: `fix: bound h1 open() with timeout, detect dead h2 cells synchronously`

Two changes, both `domain_fronter.rs`-only:

- **`H1_OPEN_TIMEOUT_SECS = 8`** wraps the TCP+TLS handshake in `open()`
  - Without it, a stuck handshake to a blackholed `connect_host:443` blocks `acquire()` (and the `warm()` prewarm loop) until the outer 30 s batch budget elapses
  - Same symptom #924 hits during the warm-race window
- **`H2Cell.dead: Arc<AtomicBool>`** flipped by the connection driver task when `Connection::await` ends (GOAWAY, network error, normal close)
  - `ensure_h2`'s fast path and `run_pool_refill`'s pool-target check both consult the flag
  - A known-dead cell is rejected within ≤5 s instead of waiting for `H2_CONN_TTL_SECS` (540 s) to expire or for a request to discover the breakage via `ready()` failure

API impact:

- `h2_handshake_post_tls`'s return type changes to `(SendRequest, Arc<AtomicBool>)`
- One existing test (`h2_handshake_post_tls_returns_alpn_refused_when_peer_picks_h1`) tweaks its `Ok` arm to match — panic message unchanged

## Testing

### Unit + integration

- **209 lib tests** pass (was 208; added `ensure_h2_rejects_dead_cell_within_ttl`)
- **36 tunnel-node tests** pass

```
cargo test --lib
cargo test --manifest-path tunnel-node/Cargo.toml
```

### Live end-to-end

Topology:

- macOS arm64 client
- → Tailscale exit-node Hetzner Helsinki
- → Google edge `216.239.38.120`
- → Apps Script (web app deployment)
- → cloudflared quick-tunnel
- → tunnel-node v1.9.18 in local Docker
- → real internet

| Scenario | Result |
|---|---|
| 5 cold restarts (warm-up race window) | ✅ 5/5 — 9.6 s, 13.0 s, 22.5 s, 16.4 s, 10.6 s |
| Concurrent burst (5 simultaneous SOCKS5 streams) | ✅ 5/5 — all completed in 10.29 s (h2 multiplex) |
| Default `full.json` baseline (no `force_http1`) | ✅ 200 OK in 13.3 s |
| `force_http1: true` (sanity, h2 disabled) | ✅ 200 OK in 17.7 s |

### A/B vs PR #903 (per-session pipelining, currently approved-but-unmerged)

- Cherry-picked these two commits onto `pr/903` head
- Both auto-merged without conflict
- Changes are in disjoint functions:
  - This PR: `warm()` / `open()` / `H2Cell`
  - PR #903: `tunnel_batch_request_to` / `parse_redirect` / `read_http_response_with_timeout`

| Branch | Pass rate (5 alternating cold restarts) | Mean probe time |
|---|---|---|
| `pr/903` alone | 5/5 | 8.86 s |
| `pr/903` + this PR | 5/5 | 6.78 s |

If #903 lands first, this PR will need a small rebase but the overlap is mechanical.

## Reproducing

A public-facing tunnel-node is required (Apps Script lives in Google's cloud, can't reach localhost).

1. **Stand up tunnel-node + a public URL:**
   ```bash
   docker run -d --name mhrv-tunnel-test \
     -p 127.0.0.1:8080:8080 \
     -e TUNNEL_AUTH_KEY="$(openssl rand -hex 24)" \
     ghcr.io/therealaleph/mhrv-tunnel-node:latest
   cloudflared tunnel --no-autoupdate --protocol http2 --url http://127.0.0.1:8080
   ```
   (Or use a real VPS / Cloud Run / GitHub Actions — see `assets/github-actions-tunnel/`.)

2. **Deploy `assets/apps_script/CodeFull.gs`** as a Web App with:
   - `TUNNEL_SERVER_URL` pointing at the URL from step 1
   - `TUNNEL_AUTH_KEY` matching the `docker run -e` value
   - A fresh `AUTH_KEY`
   - "Execute as: Me", "Who has access: Anyone"

3. **Write `config.full.json`** with:
   - `"mode": "full"`
   - `"google_ip": "216.239.38.120"`
   - `"front_domain": "www.google.com"`
   - The deployment ID as `script_id`
   - The matching `auth_key`

4. **Reproduce the regression on `v1.9.15`:**
   ```bash
   git worktree add ../mhrv-v1915 v1.9.15
   cd ../mhrv-v1915
   cargo build --bin mhrv-rs
   ./target/debug/mhrv-rs --config /path/to/config.full.json &
   curl --socks5-hostname 127.0.0.1:8086 --max-time 30 https://api.ipify.org?format=json
   # → curl: (28) SSL connection timeout (within ~12 s)
   ```

5. **Verify on this branch:**
   ```bash
   git checkout fix/full-mode-warm-race-924
   cargo build --bin mhrv-rs
   ./target/debug/mhrv-rs --config /path/to/config.full.json &
   curl --socks5-hostname 127.0.0.1:8086 --max-time 30 https://api.ipify.org?format=json
   # → 200 OK with {"ip": "..."} body, typically 5–17 s
   ```

Probe-time variance comes from the Tailscale / Apps Script / cloudflared chain, not the proxy itself. On a direct VPS path, expect 3–5 s.

## Out of scope

- **`H2_OPEN_TIMEOUT_SECS` (8 s) occasionally hitting on a cold first connection.** Variable network behaviour (Apps Script container warm-up, Google edge cache miss, exit-node tunneling latency), not a code bug. The warm-race + dead-flag + open-timeout fixes in this PR mean a slow h2 init is gracefully handled by the warm h1 pool.
- **ngrok-free.dev / trycloudflare DNS-blocking at TCI (Iran ISP).** Tracked separately in #924's discussion.
- **Mid-session h2 stability ("works for hours then dies" reports).** The dead-flag fix closes one mechanism (silent stale-cell reuse); broader long-running stability tracked separately.
