### PR TITLE
fix(code.gs): wrap _doSingle normal-relay fetch in try/catch

### DIFF
--- a/assets/apps_script/Code.gs
+++ b/assets/apps_script/Code.gs
@@ -189,13 +189,27 @@ function _doSingle(req) {
   }
 
   // ── Normal relay (cache disabled or unavailable) ────────
-  var opts = _buildOpts(req);
-  var resp = UrlFetchApp.fetch(req.u, opts);
-  return _json({
-    s: resp.getResponseCode(),
-    h: _respHeaders(resp),
-    b: Utilities.base64Encode(resp.getContent()),
-  });
+  // Wrap the fetch + body encode in try/catch so any failure surfaces as
+  // a JSON error envelope the Rust client can parse. Without this, throws
+  // from UrlFetchApp.fetch (URL too long, payload too large, quota
+  // exhausted, 6-minute execution timeout) or from base64Encode (response
+  // body near Apps Script's ~50 MB ceiling can blow the V8 heap during
+  // encode) propagate unhandled, and Apps Script serves its default
+  // `<title>Web App</title>` HTML error page — which the client then
+  // reports as "Relay failed: bad response: no json in: <title>Web App>..."
+  // and the user has no signal as to the actual cause. Mirrors the
+  // per-item try/catch in _doBatch below.
+  try {
+    var opts = _buildOpts(req);
+    var resp = UrlFetchApp.fetch(req.u, opts);
+    return _json({
+      s: resp.getResponseCode(),
+      h: _respHeaders(resp),
+      b: Utilities.base64Encode(resp.getContent()),
+    });
+  } catch (err) {
+    return _json({ e: "fetch failed: " + String(err) });
+  }
 }
 
 // ── Batch Request ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #1047.

When `_doSingle` falls through to the normal relay path (cache disabled, or cache miss on a non-cachable request), the `UrlFetchApp.fetch` → `getContent` → `base64Encode` chain ran with no error wrapper. Any throw — most commonly when the response body approaches Apps Script's ~50 MB ceiling and `base64Encode` blows the V8 heap, but also URL-too-long, payload-too-large, quota exhaustion, or the 6-minute execution timeout — propagated unhandled, and Apps Script served its default `<title>Web App</title>` HTML error page in place of our JSON envelope.

The Rust client (`parse_relay_json` in `src/domain_fronter.rs`) then failed to find any JSON in the response and surfaced the cryptic `bad response: no json in: <!DOCTYPE html>...` error, giving the user no signal as to the actual cause.

The reporter's symptom — a single failing host (`shc-dist.lostsig.co`, sonichacking.org) serving large ROM-hack binaries — matches this exactly: every other download worked because they were all comfortably under the body-size ceiling.

## Fix

Wrap the normal-relay block in `_doSingle` with `try { ... } catch (err) { return _json({ e: "fetch failed: " + String(err) }); }`. This mirrors the per-item try/catch already present in `_doBatch`, and turns the silent HTML crash into a structured `FronterError::Relay("fetch failed: …")` on the client side that pinpoints the real underlying error.

The cache path is intentionally untouched:
- `_fetchAndCache` already wraps its own fetch in try/catch and returns `null` on any failure (so `_doSingle` falls through cleanly to the normal relay).
- The cached-read path is bounded to ≤ `CACHE_MAX_BODY_BYTES` (35 KB) so it cannot trip the size limits that caused this bug.

## Scope

- One file, `assets/apps_script/Code.gs`, +21 / −7.
- No behavior change for successful relays.
- No protocol/wire-format change — the `{ e: "..." }` envelope is the same shape the Rust client already handles via `FronterError::Relay`.
- No version bump or changelog entry in this PR; can be folded into the next release commit.

## Deployment note

Apps Script changes only take effect on deployments that re-paste the updated `Code.gs`. Users on existing deployments will continue to see the old HTML crash until their deployment is refreshed — there is no client-side change here to ship.
