### PR TITLE
docs(README): update community helper section with details about mhrv…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 🇬🇧 [English Quick Start](#quick-start) · [Full Guide (advanced topics)](docs/guide.md)
 🇮🇷 [راه‌اندازی سریع فارسی](#راه‌اندازی-سریع) · [راهنمای کامل (مباحث پیشرفته)](docs/guide.fa.md)
 
-**Community helper (Chrome, optional):** [`github.com/ardalan-ab/mhrv-helper-extension`](https://github.com/ardalan-ab/mhrv-helper-extension) — maintained by [@ardalan-ab](https://github.com/ardalan-ab). Extension docs: [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md) · [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md). Usage: [HOW_TO_USE.md](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md) · [HOW_TO_USE.fa.md](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md).
 
 <p align="center" dir="rtl">
   ۱. <a href="https://www.youtube.com/watch?v=voCwxgvWR5U" target="_blank" rel="noopener noreferrer">راهنمای تصویری راه اندازی به زبان فارسی</a> (YouTube)
@@ -29,12 +28,6 @@
 - ⚡ **One small file** (~3 MB), no Python, no Node.js, no dependencies
 - 🖥️ **Works on** Mac, Windows, Linux, Android, OpenWRT routers
 - 🦊 **Any browser or app** that supports HTTP proxy or SOCKS5
-
-## Community helpers
-
-Third-party tools are not required to run mhrv-rs; they are listed here for convenience.
-
-- **[mhrv-helper-extension](https://github.com/ardalan-ab/mhrv-helper-extension)** — Chrome extension (Manifest V3) maintained by **[ardalan-ab](https://github.com/ardalan-ab)**. It helps with Apps Script setup: generate an `AUTH_KEY`, fetch or fall back to canonical `Code.gs`, and copy a `config.json` snippet. **Repository:** `https://github.com/ardalan-ab/mhrv-helper-extension` — [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md) · [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md) — [How to use (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md) · [راهنمای استفاده (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md).
 
 ## How it works (the simple picture)
 
@@ -156,6 +149,12 @@ If something doesn't work:
 
 ---
 
+## Community helpers
+
+Third-party tools are not required to run mhrv-rs; they are listed here for convenience.
+
+- **[mhrv-helper-extension](https://github.com/ardalan-ab/mhrv-helper-extension)** — Chrome extension (Manifest V3) maintained by **[ardalan-ab](https://github.com/ardalan-ab)**. It helps with Apps Script setup: generate an `AUTH_KEY`, fetch or fall back to canonical `Code.gs`, and copy a `config.json` snippet. **Repository:** `https://github.com/ardalan-ab/mhrv-helper-extension` — [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md) · [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md) — [How to use (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md) · [راهنمای استفاده (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md).
+
 ## Common questions
 
 **Is this really free?** Yes. Google gives every account 20,000 outbound URL fetches per day on the free tier. That's plenty for one person's normal browsing. For a family of 3–4 sharing the same setup, make 2–3 deployments in different Google accounts and add all the IDs.
@@ -200,8 +199,6 @@ Most of the Rust code in this port was written with [Anthropic's Claude](https:/
 🇬🇧 [English Quick Start](#quick-start) · [Full Guide (advanced)](docs/guide.md)
 🇮🇷 [راه‌اندازی سریع](#راه‌اندازی-سریع) · [راهنمای کامل (پیشرفته)](docs/guide.fa.md)
 
-**ابزار جامعه (افزونهٔ کروم، اختیاری):** [`github.com/ardalan-ab/mhrv-helper-extension`](https://github.com/ardalan-ab/mhrv-helper-extension) — نگهداری [@ardalan-ab](https://github.com/ardalan-ab). مستندات افزونه: [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md) · [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md). راهنمای گام‌به‌گام: [HOW_TO_USE.fa.md](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md) · [HOW_TO_USE.md](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md).
-
 ## چی به دست می‌آوری
 
 - 🌐 **عبور از DPI / مسدودسازی SNI** با لبهٔ گوگل به‌عنوان رله
@@ -210,13 +207,7 @@ Most of the Rust code in this port was written with [Anthropic's Claude](https:/
 - 🖥️ **روی** مک، ویندوز، لینوکس، اندروید، روتر OpenWRT کار می‌کند
 - 🦊 **هر مرورگر یا برنامه‌ای** که از HTTP proxy یا SOCKS5 پشتیبانی کند
 
-## ابزارهای جامعه
 
-برای اجرای mhrv-rs به این ابزارها نیاز نیست؛ فقط برای راحتی اینجا آمده‌اند.
-- افزونهٔ [mhrv-helper-extension](https://github.com/ardalan-ab/mhrv-helper-extension) — کروم (Manifest V3) با نگهداری [ardalan-ab](https://github.com/ardalan-ab) برای کمک در راه‌اندازی Apps Script: تولید AUTH_KEY، گرفتن یا fallback به Code.gs رسمی، و کپی قطعهٔ config.json.
-- مخزن: https://github.com/ardalan-ab/mhrv-helper-extension
-- خواندن [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md) · [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md)
-- راهنمای [استفاده (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md) · [How to use (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md)
 ## چطور کار می‌کند (تصویر ساده)
 
 ```
@@ -336,6 +327,14 @@ System Settings → Network → Wi-Fi → Details → **Proxies** → هر دو 
 - بخش [سؤالات رایج](#سؤالات-رایج) پایین را ببین
 
 ---
+## ابزارهای جامعه
+
+برای اجرای mhrv-rs به این ابزارها نیاز نیست؛ فقط برای راحتی اینجا آمده‌اند.
+- افزونهٔ [mhrv-helper-extension](https://github.com/ardalan-ab/mhrv-helper-extension) — کروم (Manifest V3) با نگهداری [ardalan-ab](https://github.com/ardalan-ab) برای کمک در راه‌اندازی Apps Script: تولید AUTH_KEY، گرفتن یا fallback به Code.gs رسمی، و کپی قطعهٔ config.json.
+- مخزن: https://github.com/ardalan-ab/mhrv-helper-extension
+- خواندن [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md) · [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md)
+- راهنمای [استفاده (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md) · [How to use (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md)
+
 
 ## سؤالات رایج
 

--- a/README.md
+++ b/README.md
@@ -213,9 +213,10 @@ Most of the Rust code in this port was written with [Anthropic's Claude](https:/
 ## ابزارهای جامعه
 
 برای اجرای mhrv-rs به این ابزارها نیاز نیست؛ فقط برای راحتی اینجا آمده‌اند.
-
-- **[mhrv-helper-extension](https://github.com/ardalan-ab/mhrv-helper-extension)** — افزونهٔ کروم (Manifest V3) با نگهداری **[ardalan-ab](https://github.com/ardalan-ab)** برای کمک در راه‌اندازی Apps Script: تولید `AUTH_KEY`، گرفتن یا fallback به `Code.gs` رسمی، و کپی قطعهٔ `config.json`. **مخزن:** `https://github.com/ardalan-ab/mhrv-helper-extension` — [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md) · [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md) — [راهنمای استفاده (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md) · [How to use (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md).
-
+- افزونهٔ [mhrv-helper-extension](https://github.com/ardalan-ab/mhrv-helper-extension) — کروم (Manifest V3) با نگهداری [ardalan-ab](https://github.com/ardalan-ab) برای کمک در راه‌اندازی Apps Script: تولید AUTH_KEY، گرفتن یا fallback به Code.gs رسمی، و کپی قطعهٔ config.json.
+- مخزن: https://github.com/ardalan-ab/mhrv-helper-extension
+- خواندن [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md) · [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md)
+- راهنمای [استفاده (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md) · [How to use (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md)
 ## چطور کار می‌کند (تصویر ساده)
 
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 🇬🇧 [English Quick Start](#quick-start) · [Full Guide (advanced topics)](docs/guide.md)
 🇮🇷 [راه‌اندازی سریع فارسی](#راه‌اندازی-سریع) · [راهنمای کامل (مباحث پیشرفته)](docs/guide.fa.md)
 
+**Community helper (Chrome, optional):** [`github.com/ardalan-ab/mhrv-helper-extension`](https://github.com/ardalan-ab/mhrv-helper-extension) — maintained by [@ardalan-ab](https://github.com/ardalan-ab). Extension docs: [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md) · [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md). Usage: [HOW_TO_USE.md](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md) · [HOW_TO_USE.fa.md](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md).
+
 <p align="center" dir="rtl">
   ۱. <a href="https://www.youtube.com/watch?v=voCwxgvWR5U" target="_blank" rel="noopener noreferrer">راهنمای تصویری راه اندازی به زبان فارسی</a> (YouTube)
   <br>
@@ -27,6 +29,12 @@
 - ⚡ **One small file** (~3 MB), no Python, no Node.js, no dependencies
 - 🖥️ **Works on** Mac, Windows, Linux, Android, OpenWRT routers
 - 🦊 **Any browser or app** that supports HTTP proxy or SOCKS5
+
+## Community helpers
+
+Third-party tools are not required to run mhrv-rs; they are listed here for convenience.
+
+- **[mhrv-helper-extension](https://github.com/ardalan-ab/mhrv-helper-extension)** — Chrome extension (Manifest V3) maintained by **[ardalan-ab](https://github.com/ardalan-ab)**. It helps with Apps Script setup: generate an `AUTH_KEY`, fetch or fall back to canonical `Code.gs`, and copy a `config.json` snippet. **Repository:** `https://github.com/ardalan-ab/mhrv-helper-extension` — [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md) · [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md) — [How to use (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md) · [راهنمای استفاده (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md).
 
 ## How it works (the simple picture)
 
@@ -74,6 +82,8 @@ ISPs can't read inside encrypted HTTPS. They only see the address — `www.googl
 11. Google shows a **Deployment ID** (a long random string). **Copy it** — you'll need it in Step 3.
 
 > **Tip:** if you ever update `Code.gs` later, don't make a new deployment. Edit the code, then go to **Deploy → Manage deployments → ✏️ → Version: New version → Deploy**. The Deployment ID stays the same.
+>
+> **Optional:** use the community [Chrome extension](https://github.com/ardalan-ab/mhrv-helper-extension) — see [How to use](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md) (English) or [راهنمای فارسی](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md).
 
 ### Step 2 — Download mhrv-rs
 
@@ -190,6 +200,8 @@ Most of the Rust code in this port was written with [Anthropic's Claude](https:/
 🇬🇧 [English Quick Start](#quick-start) · [Full Guide (advanced)](docs/guide.md)
 🇮🇷 [راه‌اندازی سریع](#راه‌اندازی-سریع) · [راهنمای کامل (پیشرفته)](docs/guide.fa.md)
 
+**ابزار جامعه (افزونهٔ کروم، اختیاری):** [`github.com/ardalan-ab/mhrv-helper-extension`](https://github.com/ardalan-ab/mhrv-helper-extension) — نگهداری [@ardalan-ab](https://github.com/ardalan-ab). مستندات افزونه: [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md) · [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md). راهنمای گام‌به‌گام: [HOW_TO_USE.fa.md](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md) · [HOW_TO_USE.md](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md).
+
 ## چی به دست می‌آوری
 
 - 🌐 **عبور از DPI / مسدودسازی SNI** با لبهٔ گوگل به‌عنوان رله
@@ -197,6 +209,12 @@ Most of the Rust code in this port was written with [Anthropic's Claude](https:/
 - ⚡ **یک فایل کوچک** (~۳ مگابایت)، بدون پایتون، بدون Node.js، بدون وابستگی
 - 🖥️ **روی** مک، ویندوز، لینوکس، اندروید، روتر OpenWRT کار می‌کند
 - 🦊 **هر مرورگر یا برنامه‌ای** که از HTTP proxy یا SOCKS5 پشتیبانی کند
+
+## ابزارهای جامعه
+
+برای اجرای mhrv-rs به این ابزارها نیاز نیست؛ فقط برای راحتی اینجا آمده‌اند.
+
+- **[mhrv-helper-extension](https://github.com/ardalan-ab/mhrv-helper-extension)** — افزونهٔ کروم (Manifest V3) با نگهداری **[ardalan-ab](https://github.com/ardalan-ab)** برای کمک در راه‌اندازی Apps Script: تولید `AUTH_KEY`، گرفتن یا fallback به `Code.gs` رسمی، و کپی قطعهٔ `config.json`. **مخزن:** `https://github.com/ardalan-ab/mhrv-helper-extension` — [README (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.fa.md) · [README (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/README.md) — [راهنمای استفاده (فارسی)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md) · [How to use (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md).
 
 ## چطور کار می‌کند (تصویر ساده)
 
@@ -244,6 +262,8 @@ ISP داخل HTTPS رمزشده را نمی‌تواند بخواند. فقط آ
 ۱۱. گوگل یک **Deployment ID** نشانت می‌دهد (یک رشتهٔ تصادفی طولانی). **کپی‌اش کن** — در مرحلهٔ ۳ لازم داری.
 
 > **نکته:** اگر بعداً `Code.gs` را به‌روزرسانی کنی، Deployment جدید نساز. کد را ویرایش کن، بعد **Deploy → Manage deployments → ✏️ → Version: New version → Deploy**. Deployment ID همان قبلی می‌ماند.
+>
+> **اختیاری:** افزونهٔ اختیاری کروم [mhrv-helper-extension](https://github.com/ardalan-ab/mhrv-helper-extension) — [راهنمای فارسی](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.fa.md) · [How to use (English)](https://github.com/ardalan-ab/mhrv-helper-extension/blob/main/HOW_TO_USE.md).
 
 ### مرحلهٔ ۲ — دانلود mhrv-rs
 


### PR DESCRIPTION
## Description

This PR adds a small "Community Helpers" section to the README linking to the external extension repository:

- https://github.com/ardalan-ab/mhrv-helper-extension

The extension is now maintained separately to keep the main repository focused on the proxy + Apps Script core while still making the helper tool discoverable for users.

Since the previous review, the extension repository also includes:

- a CI sync check to ensure `chrome-extension/Code.gs` stays synchronized with `assets/apps_script/Code.gs`
- additional basic test coverage improvements
- a version-check mechanism for extension updates

I’m also open to the extension being published under your account for consistency and user trust, while still continuing maintenance and contribution on my side.

This follows the direction discussed in the earlier PR review.

---

## ترجمه فارسی

این PR یک بخش کوچک با عنوان "Community Helpers" به README اضافه می‌کند که به ریپازیتوری جداگانه افزونه لینک می‌دهد:

- https://github.com/ardalan-ab/mhrv-helper-extension

افزونه اکنون به‌صورت جداگانه نگهداری می‌شود تا ریپازیتوری اصلی روی هسته پروژه (proxy و Apps Script) متمرکز باقی بماند و در عین حال این ابزار کمکی همچنان برای کاربران قابل دسترس باشد.

همچنین بعد از ریویوی قبلی، موارد زیر به ریپازیتوری افزونه اضافه شده‌اند:

- CI sync check برای اطمینان از همگام بودن `chrome-extension/Code.gs` و `assets/apps_script/Code.gs`
- بهبود پوشش تست‌های اولیه
- قابلیت بررسی نسخه برای اطلاع از جدیدترین نسخه افزونه

همچنین من مشکلی ندارم که افزونه برای هماهنگی بیشتر و اعتماد کاربران تحت اکانت شما منتشر شود، در حالی که همچنان نگهداری و توسعه آن را ادامه می‌دهم.

این PR بر اساس مسیر پیشنهادی در ریویوی قبلی ایجاد شده است.