### PR TITLE
FreeBSD native build workflow

### DIFF
--- a/.github/workflows/freebsd-build.yml
+++ b/.github/workflows/freebsd-build.yml
@@ -1,0 +1,56 @@
+name: FreeBSD Rust Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  freebsd:
+    name: FreeBSD ${{ matrix.freebsd-version }} / ${{ matrix.target }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - freebsd-version: "14.2"
+            target: x86_64-unknown-freebsd
+          - freebsd-version: "15.0"
+            target: x86_64-unknown-freebsd
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build on FreeBSD ${{ matrix.freebsd-version }}
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: ${{ matrix.freebsd-version }}
+          usesh: true
+          prepare: |
+            pkg install -y curl git bash gmake pkgconf
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+          run: |
+            set -e
+            . "$HOME/.cargo/env"
+
+            rustup default stable
+            rustc --version
+            cargo --version
+
+            cargo build --release
+
+            mkdir -p dist
+            BIN_NAME="your-binary-name"
+
+            cp "target/release/$BIN_NAME" "dist/${BIN_NAME}-freebsd-${{ matrix.freebsd-version }}-x86_64"
+            tar -C dist -czf "dist/${BIN_NAME}-freebsd-${{ matrix.freebsd-version }}-x86_64.tar.gz" "${BIN_NAME}-freebsd-${{ matrix.freebsd-version }}-x86_64"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: freebsd-${{ matrix.freebsd-version }}-x86_64
+          path: dist/*.tar.gz

--- a/.github/workflows/freebsd-build.yml
+++ b/.github/workflows/freebsd-build.yml
@@ -34,7 +34,8 @@ jobs:
             rustc --version
             cargo --version
 
-            cargo build --release --bin mhrv-rs --bin mhrv-rs-ui
+            cargo build --release --bin mhrv-rs
+            cargo build --release --features ui --bin mhrv-rs-ui
 
             mkdir -p dist/freebsd-x86_64
 

--- a/.github/workflows/freebsd-build.yml
+++ b/.github/workflows/freebsd-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   freebsd:
-    name: FreeBSD x86_64
+    name: FreeBSD amd64
     runs-on: ubuntu-latest
 
     steps:
@@ -37,17 +37,17 @@ jobs:
             cargo build --release --bin mhrv-rs
             cargo build --release --features ui --bin mhrv-rs-ui
 
-            mkdir -p dist/freebsd-x86_64
+            mkdir -p dist
 
-            cp target/release/mhrv-rs dist/freebsd-x86_64/
-            cp target/release/mhrv-rs-ui dist/freebsd-x86_64/
+            cp target/release/mhrv-rs dist/mhrv-rs
+            cp target/release/mhrv-rs-ui dist/mhrv-rs-ui
 
             tar -C dist \
-              -czf mhrv-rs-freebsd-x86_64.tar.gz \
-              freebsd-x86_64
+              -czf dist/mhrv-rs-freebsd-amd64.tar.gz \
+              mhrv-rs mhrv-rs-ui
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: mhrv-rs-freebsd-x86_64
-          path: mhrv-rs-freebsd-x86_64.tar.gz
+          name: mhrv-rs-freebsd-amd64
+          path: dist/mhrv-rs-freebsd-amd64.tar.gz

--- a/.github/workflows/freebsd-build.yml
+++ b/.github/workflows/freebsd-build.yml
@@ -9,48 +9,44 @@ on:
 
 jobs:
   freebsd:
-    name: FreeBSD ${{ matrix.freebsd-version }} / ${{ matrix.target }}
+    name: FreeBSD x86_64
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - freebsd-version: "14.2"
-            target: x86_64-unknown-freebsd
-          - freebsd-version: "15.0"
-            target: x86_64-unknown-freebsd
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build on FreeBSD ${{ matrix.freebsd-version }}
+      - name: Build on FreeBSD 15.0
         uses: vmactions/freebsd-vm@v1
         with:
-          release: ${{ matrix.freebsd-version }}
+          release: "15.0"
           usesh: true
           prepare: |
-            pkg install -y curl git bash gmake pkgconf
+            pkg install -y curl git bash gmake pkgconf openssl
             curl https://sh.rustup.rs -sSf | sh -s -- -y
           run: |
             set -e
+
             . "$HOME/.cargo/env"
 
             rustup default stable
+
             rustc --version
             cargo --version
 
-            cargo build --release
+            cargo build --release --bin mhrv-rs --bin mhrv-rs-ui
 
-            mkdir -p dist
-            BIN_NAME="your-binary-name"
+            mkdir -p dist/freebsd-x86_64
 
-            cp "target/release/$BIN_NAME" "dist/${BIN_NAME}-freebsd-${{ matrix.freebsd-version }}-x86_64"
-            tar -C dist -czf "dist/${BIN_NAME}-freebsd-${{ matrix.freebsd-version }}-x86_64.tar.gz" "${BIN_NAME}-freebsd-${{ matrix.freebsd-version }}-x86_64"
+            cp target/release/mhrv-rs dist/freebsd-x86_64/
+            cp target/release/mhrv-rs-ui dist/freebsd-x86_64/
+
+            tar -C dist \
+              -czf mhrv-rs-freebsd-x86_64.tar.gz \
+              freebsd-x86_64
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: freebsd-${{ matrix.freebsd-version }}-x86_64
-          path: dist/*.tar.gz
+          name: mhrv-rs-freebsd-x86_64
+          path: mhrv-rs-freebsd-x86_64.tar.gz


### PR DESCRIPTION
I've added a FreeBSD native build workflow to github actions. It doesn't use cross-compilation and uses a native FreeBSD image directly so it's defined outside `matrix.name`. Build succeeds. It doesn't include `run.sh` file, so you might want to add that (I don't know how).

FreeBSD has been very susceptible due to [not having Iran pkg servers](https://forums.freebsd.org/threads/cant-access-freebsd-packages-due-to-filtering.101546/). This is an attempt to bring FreeBSD online for Iranian users.
