### PR TITLE
fix(exit-node): fix double-wrapped response envelope and panic in error paths

### DIFF
--- a/assets/apps_script/Code.gs
+++ b/assets/apps_script/Code.gs
@@ -161,6 +161,9 @@ function _doSingle(req) {
     return _json({ e: "bad url" });
   }
 
+  // ── Optional cache path ────────────────────────────────
+  // Only entered when CACHE_SPREADSHEET_ID is configured and
+  // the request qualifies as a public, cachable GET.
   if (_canUseCache(req)) {
     var cached = _getFromCache(req.u, req.h);
     if (cached) {
@@ -181,25 +184,41 @@ function _doSingle(req) {
         cached: false,
       });
     }
-    // _fetchAndCache returned null → fall through to normal relay
+    // If _fetchAndCache returns null (spreadsheet unavailable),
+    // fall through to the normal relay path below.
   }
 
-  var opts = _buildOpts(req);
-  var resp = UrlFetchApp.fetch(req.u, opts);
+  // ── Normal relay (cache disabled or unavailable) ────────
+  // Wrap the fetch + body encode in try/catch so any failure surfaces as
+  // a JSON error envelope the Rust client can parse. Without this, throws
+  // from UrlFetchApp.fetch (URL too long, payload too large, quota
+  // exhausted, 6-minute execution timeout) or from base64Encode (response
+  // body near Apps Script's ~50 MB ceiling can blow the V8 heap during
+  // encode) propagate unhandled, and Apps Script serves its default
+  // `<title>Web App</title>` HTML error page — which the client then
+  // reports as "Relay failed: bad response: no json in: <title>Web App>..."
+  // and the user has no signal as to the actual cause. Mirrors the
+  // per-item try/catch in _doBatch below.
+  try {
+    var opts = _buildOpts(req);
+    var resp = UrlFetchApp.fetch(req.u, opts);
 
-  // Raw-return mode for exit-node path.
-  // r:true = return destination body verbatim so Rust gets {s,h,b} unwrapped.
-  if (req.r === true) {
-    return ContentService
-      .createTextOutput(resp.getContentText())
-      .setMimeType(ContentService.MimeType.JSON);
+    // Raw-return mode for exit-node path.
+    // r:true = return destination body verbatim so Rust gets {s,h,b} unwrapped.
+    if (req.r === true) {
+      return ContentService
+        .createTextOutput(resp.getContentText())
+        .setMimeType(ContentService.MimeType.JSON);
+    }
+
+    return _json({
+      s: resp.getResponseCode(),
+      h: _respHeaders(resp),
+      b: Utilities.base64Encode(resp.getContent()),
+    });
+  } catch (err) {
+    return _json({ e: "fetch failed: " + String(err) });
   }
-
-  return _json({
-    s: resp.getResponseCode(),
-    h: _respHeaders(resp),
-    b: Utilities.base64Encode(resp.getContent()),
-  });
 }
 
 // ── Batch Request ──────────────────────────────────────────

--- a/assets/apps_script/Code.gs
+++ b/assets/apps_script/Code.gs
@@ -161,9 +161,6 @@ function _doSingle(req) {
     return _json({ e: "bad url" });
   }
 
-  // ── Optional cache path ────────────────────────────────
-  // Only entered when CACHE_SPREADSHEET_ID is configured and
-  // the request qualifies as a public, cachable GET.
   if (_canUseCache(req)) {
     var cached = _getFromCache(req.u, req.h);
     if (cached) {
@@ -184,32 +181,25 @@ function _doSingle(req) {
         cached: false,
       });
     }
-    // If _fetchAndCache returns null (spreadsheet unavailable),
-    // fall through to the normal relay path below.
+    // _fetchAndCache returned null → fall through to normal relay
   }
 
-  // ── Normal relay (cache disabled or unavailable) ────────
-  // Wrap the fetch + body encode in try/catch so any failure surfaces as
-  // a JSON error envelope the Rust client can parse. Without this, throws
-  // from UrlFetchApp.fetch (URL too long, payload too large, quota
-  // exhausted, 6-minute execution timeout) or from base64Encode (response
-  // body near Apps Script's ~50 MB ceiling can blow the V8 heap during
-  // encode) propagate unhandled, and Apps Script serves its default
-  // `<title>Web App</title>` HTML error page — which the client then
-  // reports as "Relay failed: bad response: no json in: <title>Web App>..."
-  // and the user has no signal as to the actual cause. Mirrors the
-  // per-item try/catch in _doBatch below.
-  try {
-    var opts = _buildOpts(req);
-    var resp = UrlFetchApp.fetch(req.u, opts);
-    return _json({
-      s: resp.getResponseCode(),
-      h: _respHeaders(resp),
-      b: Utilities.base64Encode(resp.getContent()),
-    });
-  } catch (err) {
-    return _json({ e: "fetch failed: " + String(err) });
+  var opts = _buildOpts(req);
+  var resp = UrlFetchApp.fetch(req.u, opts);
+
+  // Raw-return mode for exit-node path.
+  // r:true = return destination body verbatim so Rust gets {s,h,b} unwrapped.
+  if (req.r === true) {
+    return ContentService
+      .createTextOutput(resp.getContentText())
+      .setMimeType(ContentService.MimeType.JSON);
   }
+
+  return _json({
+    s: resp.getResponseCode(),
+    h: _respHeaders(resp),
+    b: Utilities.base64Encode(resp.getContent()),
+  });
 }
 
 // ── Batch Request ──────────────────────────────────────────
@@ -307,7 +297,7 @@ function _buildOpts(req) {
   var opts = {
     method: (req.m || "GET").toLowerCase(),
     muteHttpExceptions: true,
-    followRedirects: req.r !== false,
+    followRedirects: true,          // ← always true; r flag now has different meaning
     validateHttpsCertificates: true,
     escaping: false,
   };

--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -3037,7 +3037,7 @@ impl DomainFronter {
             let start = text.find('{').ok_or_else(|| {
                 FronterError::BadResponse(format!(
                     "no json in tunnel response: {}",
-                    &text[..text.len().min(200)]
+                    &text.chars().take(200).collect::<String>()
                 ))
             })?;
             let end = text.rfind('}').ok_or_else(|| {
@@ -3205,7 +3205,7 @@ impl DomainFronter {
             let start = text.find('{').ok_or_else(|| {
                 FronterError::BadResponse(format!(
                     "no json in batch response: {}",
-                    &text[..text.len().min(200)]
+                    &text.chars().take(200).collect::<String>()
                 ))
             })?;
             let end = text.rfind('}').ok_or_else(|| {
@@ -4578,13 +4578,13 @@ fn parse_relay_json(body: &[u8]) -> Result<Vec<u8>, FronterError> {
                 let start = text.find('{').ok_or_else(|| {
                     FronterError::BadResponse(format!(
                         "no json in: {}",
-                        &text[..text.len().min(200)]
+                        &text.chars().take(200).collect::<String>()
                     ))
                 })?;
                 let end = text.rfind('}').ok_or_else(|| {
                     FronterError::BadResponse(format!(
                         "no json end in: {}",
-                        &text[..text.len().min(200)]
+                        &text.chars().take(200).collect::<String>()
                     ))
                 })?;
                 serde_json::from_str(&text[start..=end])?

--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -2686,14 +2686,15 @@ impl DomainFronter {
             .send_prebuilt_payload_through_relay(outer_payload)
             .await?;
 
-        tracing::warn!(
+        // temporary diagnostics for exit-node response debugging.
+        // Logs the raw app_body before parse_exit_node_response() is called.
+        tracing::debug!(
             "EXIT_DIAG app_body len={} first_200={:?}",
             app_body.len(),
             String::from_utf8_lossy(&app_body[..app_body.len().min(200)])
         );
 
         let result = parse_exit_node_response(&app_body);
-        tracing::warn!("EXIT_DIAG parse_result ok={}", result.is_ok());
         result
     }
 
@@ -3969,7 +3970,7 @@ fn unix_to_ymd_utc(secs: u64) -> (i64, u32, u32) {
 fn parse_exit_node_response(body: &[u8]) -> Result<Vec<u8>, FronterError> {
     let json_start = body
         .windows(4)
-        .position(|w| w == b"\r\n\r\n") 
+        .position(|w| w == b"\r\n\r\n")
         .map(|i| i + 4)
         .unwrap_or(0);
     let json_bytes = &body[json_start..];

--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -2685,15 +2685,7 @@ impl DomainFronter {
         let app_body = self
             .send_prebuilt_payload_through_relay(outer_payload)
             .await?;
-
-        // temporary diagnostics for exit-node response debugging.
-        // Logs the raw app_body before parse_exit_node_response() is called.
-        tracing::debug!(
-            "EXIT_DIAG app_body len={} first_200={:?}",
-            app_body.len(),
-            String::from_utf8_lossy(&app_body[..app_body.len().min(200)])
-        );
-
+         
         let result = parse_exit_node_response(&app_body);
         result
     }

--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -2686,9 +2686,15 @@ impl DomainFronter {
             .send_prebuilt_payload_through_relay(outer_payload)
             .await?;
 
-        // exit-node's JSON envelope: {s: u16, h: {...}, b: "<base64>"} on
-        // success, {e: "..."} on its own internal error.
-        parse_exit_node_response(&app_body)
+        tracing::warn!(
+            "EXIT_DIAG app_body len={} first_200={:?}",
+            app_body.len(),
+            String::from_utf8_lossy(&app_body[..app_body.len().min(200)])
+        );
+
+        let result = parse_exit_node_response(&app_body);
+        tracing::warn!("EXIT_DIAG parse_result ok={}", result.is_ok());
+        result
     }
 
     /// Build the inner-layer payload that the exit node will execute.
@@ -3961,11 +3967,17 @@ fn unix_to_ymd_utc(secs: u64) -> (i64, u32, u32) {
 /// MITM TLS write-back path sees the same shape it gets from the regular
 /// Apps Script relay (status line + headers + body).
 fn parse_exit_node_response(body: &[u8]) -> Result<Vec<u8>, FronterError> {
-    let v: Value = serde_json::from_slice(body).map_err(|e| {
+    let json_start = body
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n") 
+        .map(|i| i + 4)
+        .unwrap_or(0);
+    let json_bytes = &body[json_start..];
+    let v: Value = serde_json::from_slice(json_bytes).map_err(|e| {
         FronterError::Relay(format!(
             "exit-node response not valid JSON ({}): {}",
             e,
-            String::from_utf8_lossy(&body[..body.len().min(200)])
+            String::from_utf8_lossy(&json_bytes[..json_bytes.len().min(200)])
         ))
     })?;
 
@@ -4001,6 +4013,7 @@ fn parse_exit_node_response(body: &[u8]) -> Result<Vec<u8>, FronterError> {
         "transfer-encoding",
         "connection",
         "keep-alive",
+        "content-encoding", // exit node's fetch() auto-decompresses; header is stale
     ];
 
     let mut out = Vec::with_capacity(body_bytes.len() + 256);


### PR DESCRIPTION
Fixed two bugs in the exit-node relay path.

**Commit 1** fixes #1022 — Code.gs was double-wrapping the exit node's
{s,h,b} response envelope, causing browsers to receive raw JSON instead
of page content. Adds the raw-return mode (req.r === true) to _doSingle
and fixes parse_exit_node_response to handle HTTP framing prefixes and
stale content-encoding headers.

**Commit 2** fixes a panic (SIGILL/core dump) in four error format strings
that sliced a &str at byte offset 200, which crashes when the response
contains multi-byte UTF-8 characters (quota error pages, binary responses).
Replaced with char-aware truncation.

Tested against claude.ai, chatgpt.com, openai.com, perplexity.ai and general browsing with both
WARP and direct exit-node modes.