### PR TITLE
Update config.fronting-groups.example.json

### DIFF
--- a/config.fronting-groups.example.json
+++ b/config.fronting-groups.example.json
@@ -44,8 +44,8 @@
     },
     {
       "name": "fastly",
-      "ip": "151.101.128.223",
-      "sni": "files.pythonhosted.org",
+      "ip": "185.199.109.215",
+      "sni": "github.githubassets.com",
       "domains": [
         "redd.it",
         "reddit.com",

--- a/config.fronting-groups.example.json
+++ b/config.fronting-groups.example.json
@@ -45,7 +45,7 @@
     {
       "name": "fastly",
       "ip": "151.101.128.223",
-      "sni": "pypi.org",
+      "sni": "files.pythonhosted.org",
       "domains": [
         "redd.it",
         "reddit.com",
@@ -59,10 +59,6 @@
         "redditspace.com",
         "redditstatus.com",
         "reddit.map.fastly.net",
-
-        "githubassets.com",
-        "githubusercontent.com",
-        "github.io",
 
         "fastly.com",
         "fastly-edge.com",
@@ -100,14 +96,16 @@
       ]
     },
     {
-      "name": "github-central",
-      "ip": "140.82.113.21",
-      "sni": "central.github.com",
+      "name": "github-collector",
+      "ip": "140.82.113.22",
+      "sni": "collector.github.com",
       "domains": [
         "objects-origin.githubusercontent.com",
         "api.individual.githubcopilot.com",
         "glb-db52c2cf8be544.github.com",
-        "api.githubcopilot.com"
+        "api.githubcopilot.com",
+        "collector.github.com",
+        "central.github.com"
       ]
     },
     {
@@ -122,8 +120,11 @@
     {
       "name": "github",
       "ip": "140.82.121.3",
-      "sni": "github.com",
-      "domains": ["gist.github.com"]
+      "sni": "www.github.com",
+      "domains": [
+        "gist.github.com",
+        "github.com"
+      ]
     },
     {
       "name": "pubmed",


### PR DESCRIPTION
- Some minor tweaks to make Github work

We know that many fronting groups we used to use has been recently blocked. 
This commit contains some changes to make Github work better, However, still some domains (like githubassets.com) must pass through Apps Script.
My tests show that these changes will make some actions like navigating through repositories faster and more smooth. 
I'll try my best to scan and find working ips that are on Fastly edge and will make a PR in the future. 

Thanks in advance