### PR TITLE
fix(apps_script): keep Code.gs relay responses wrapped

### DIFF
--- a/assets/apps_script/Code.gs
+++ b/assets/apps_script/Code.gs
@@ -203,14 +203,6 @@ function _doSingle(req) {
     var opts = _buildOpts(req);
     var resp = UrlFetchApp.fetch(req.u, opts);
 
-    // Raw-return mode for exit-node path.
-    // r:true = return destination body verbatim so Rust gets {s,h,b} unwrapped.
-    if (req.r === true) {
-      return ContentService
-        .createTextOutput(resp.getContentText())
-        .setMimeType(ContentService.MimeType.JSON);
-    }
-
     return _json({
       s: resp.getResponseCode(),
       h: _respHeaders(resp),
@@ -316,7 +308,7 @@ function _buildOpts(req) {
   var opts = {
     method: (req.m || "GET").toLowerCase(),
     muteHttpExceptions: true,
-    followRedirects: true,          // ← always true; r flag now has different meaning
+    followRedirects: req.r !== false,
     validateHttpsCertificates: true,
     escaping: false,
   };


### PR DESCRIPTION
Fixes the v1.9.28 Code.gs JSON parse regression reported in #1245, #1253, #1261, and similar reports. The simple Code.gs path was returning the destination body verbatim when req.r was true, so the Rust client tried to parse arbitrary HTML/JSON payloads as the relay envelope. This matches CodeFull.gs by keeping responses wrapped and using req.r only to control redirect following.\n\nTests:\n- node --check /tmp/Code-1265-fix.js\n- cargo test --lib