### PR TITLE
release: prepare v1.9.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mhrv-rs"
-version = "1.9.28"
+version = "1.9.29"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mhrv-rs"
-version = "1.9.28"
+version = "1.9.29"
 edition = "2021"
 description = "Rust port of MasterHttpRelayVPN -- DPI bypass via Google Apps Script relay with domain fronting"
 license = "MIT"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.therealaleph.mhrv"
         minSdk = 24 // Android 7.0 — covers 99%+ of live devices.
         targetSdk = 34
-        versionCode = 160
-        versionName = "1.9.28"
+        versionCode = 161
+        versionName = "1.9.29"
 
         // Ship all four mainstream Android ABIs:
         //   - arm64-v8a      — 95%+ of real-world Android phones since 2019

--- a/docs/changelog/v1.9.29.md
+++ b/docs/changelog/v1.9.29.md
@@ -1,5 +1,9 @@
 <!-- see docs/changelog/v1.1.0.md for the file format: Persian, then `---`, then English. -->
-[FA] translate the English bullets below into Persian and replace this line.
+<div dir="rtl">
+
+• **رفع خطای JSON در `Code.gs` نسخه 1.9.28** ([PR #1265](https://github.com/therealaleph/MasterHttpRelayVPN-RUST/pull/1265)، [#1245](https://github.com/therealaleph/MasterHttpRelayVPN-RUST/issues/1245)، [#1253](https://github.com/therealaleph/MasterHttpRelayVPN-RUST/issues/1253)، [#1261](https://github.com/therealaleph/MasterHttpRelayVPN-RUST/issues/1261)). مسیر ساده `Code.gs` در بعضی درخواست‌ها پاسخ مقصد را خام برمی‌گرداند و کلاینت Rust آن را به‌جای envelope داخلی relay به عنوان JSON parse می‌کرد؛ نتیجه خطاهایی مثل `json: key must be a string` یا `no json in` بود. حالا `Code.gs` مثل `CodeFull.gs` پاسخ‌ها را داخل envelope `{s,h,b}` نگه می‌دارد و `req.r` فقط برای کنترل follow-redirect استفاده می‌شود. برای گرفتن این fix، فایل جدید `assets/apps_script/Code.gs` را در Apps Script جایگزین کنید و یک New version deploy بسازید.
+
+</div>
 
 ---
-• Fix Apps Script decoded range probe handling ([#337](https://github.com/therealaleph/MasterHttpRelayVPN-RUST/pull/337)): <expand>. Thanks @freeinternet865
+• **Fix the v1.9.28 `Code.gs` JSON parse regression** ([PR #1265](https://github.com/therealaleph/MasterHttpRelayVPN-RUST/pull/1265), [#1245](https://github.com/therealaleph/MasterHttpRelayVPN-RUST/issues/1245), [#1253](https://github.com/therealaleph/MasterHttpRelayVPN-RUST/issues/1253), [#1261](https://github.com/therealaleph/MasterHttpRelayVPN-RUST/issues/1261)). The simple `Code.gs` path could return the destination body verbatim for some requests, so the Rust client tried to parse arbitrary site HTML/JSON as the relay envelope and surfaced errors such as `json: key must be a string` or `no json in`. `Code.gs` now matches `CodeFull.gs`: normal relay responses stay wrapped as `{s,h,b}`, and `req.r` only controls redirect following. To get this fix, replace your Apps Script with the new `assets/apps_script/Code.gs` and deploy a New version.

--- a/docs/changelog/v1.9.29.md
+++ b/docs/changelog/v1.9.29.md
@@ -1,0 +1,5 @@
+<!-- see docs/changelog/v1.1.0.md for the file format: Persian, then `---`, then English. -->
+[FA] translate the English bullets below into Persian and replace this line.
+
+---
+• Fix Apps Script decoded range probe handling ([#337](https://github.com/therealaleph/MasterHttpRelayVPN-RUST/pull/337)): <expand>. Thanks @freeinternet865


### PR DESCRIPTION
Automated version bump for v1.9.29. I will replace the generated changelog placeholders before merge.\n\nRelease content: fix the v1.9.28 Code.gs JSON parse regression reported in #1245, #1253, #1261, and related issues.