### PR TITLE
release: prepare v1.9.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mhrv-rs"
-version = "1.9.29"
+version = "1.9.30"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mhrv-rs"
-version = "1.9.29"
+version = "1.9.30"
 edition = "2021"
 description = "Rust port of MasterHttpRelayVPN -- DPI bypass via Google Apps Script relay with domain fronting"
 license = "MIT"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.therealaleph.mhrv"
         minSdk = 24 // Android 7.0 — covers 99%+ of live devices.
         targetSdk = 34
-        versionCode = 161
-        versionName = "1.9.29"
+        versionCode = 162
+        versionName = "1.9.30"
 
         // Ship all four mainstream Android ABIs:
         //   - arm64-v8a      — 95%+ of real-world Android phones since 2019

--- a/docs/changelog/v1.9.30.md
+++ b/docs/changelog/v1.9.30.md
@@ -1,0 +1,4 @@
+<!-- see docs/changelog/v1.1.0.md for the file format: Persian, then `---`, then English. -->
+• مسیر `CodeFull.gs` برای Full mode کمی سبک‌تر شد: چند hot path در Apps Script با ساختن رشته‌ها و آرایه‌های کمتر اجرا می‌شوند تا فشار CPU/GC در batchهای پرترافیک کمتر شود. با تشکر از @brightening-eyes برای PR #1254.
+---
+• Make the Full mode `CodeFull.gs` path a little lighter: several Apps Script hot paths now allocate fewer strings/arrays, reducing CPU/GC pressure during high-traffic batches. Thanks @brightening-eyes for PR #1254.


### PR DESCRIPTION
Prepare v1.9.30 for the CodeFull.gs performance cleanup from #1254.

Verification run locally in a clean release worktree:

```text
node --check /tmp/CodeFull-v1.9.30.js
cargo test --lib
cargo build --release
cargo build --bin mhrv-rs-ui --release --features ui
JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:assembleDebug
```

---
Answered via LLM, Supervised @therealaleph