### PR TITLE
release: prepare v1.9.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mhrv-rs"
-version = "1.9.30"
+version = "1.9.31"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mhrv-rs"
-version = "1.9.30"
+version = "1.9.31"
 edition = "2021"
 description = "Rust port of MasterHttpRelayVPN -- DPI bypass via Google Apps Script relay with domain fronting"
 license = "MIT"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.therealaleph.mhrv"
         minSdk = 24 // Android 7.0 — covers 99%+ of live devices.
         targetSdk = 34
-        versionCode = 162
-        versionName = "1.9.30"
+        versionCode = 163
+        versionName = "1.9.31"
 
         // Ship all four mainstream Android ABIs:
         //   - arm64-v8a      — 95%+ of real-world Android phones since 2019

--- a/docs/changelog/v1.9.31.md
+++ b/docs/changelog/v1.9.31.md
@@ -1,0 +1,8 @@
+<!-- see docs/changelog/v1.1.0.md for the file format: Persian, then `---`, then English. -->
+• رگرسیون pipeline در Full mode که بعد از v1.9.28 می‌توانست روی sessionهای idle درخواست‌های خالی زیادی بسازد و quota چند deployment را سریع مصرف کند، اصلاح شد. مسیر keepalive دوباره backoff مرحله‌ای دارد و timer refill در حالت idle کمتر poll خالی می‌فرستد.
+• جریان داده در Full mode پایدارتر شد: پاسخ‌های خالی قدیمی که قبل از شروع جریان داده queue شده بودند دیگر streak داده را قطع نمی‌کنند، بنابراین افت زودهنگام عمق pipeline و گیر کردن ویدیوها، مخصوصاً Instagram، کمتر می‌شود.
+• default گزینه `block_stun` از این نسخه `false` است تا STUN/TURN به صورت پیش‌فرض اجازه داشته باشد؛ اگر می‌خواهید آن ترافیک را مسدود کنید، `block_stun: true` را صریحاً در config بگذارید. با تشکر از @yyoyoian-pixel برای PR #1309.
+---
+• Fix a Full mode pipeline regression introduced after v1.9.28 where idle sessions could generate too many empty polls and burn quota across multi-deployment setups. Keepalive polling now has staged backoff again, and idle refill timers schedule fewer empty polls.
+• Make Full mode data flow steadier: stale empty-poll replies queued before data starts no longer break active data streaks, reducing premature pipeline-depth drops and video stalls, especially on Instagram.
+• Change the `block_stun` default to `false`, so STUN/TURN traffic is allowed by default; set `block_stun: true` explicitly if you want to block that traffic. Thanks @yyoyoian-pixel for PR #1309.


### PR DESCRIPTION
Prepare v1.9.31 for the Full mode pipeline regression fix merged in #1309.

Release contents:

- Fix idle Full mode sessions flooding empty polls after the v1.9.28+ pipelining changes.
- Preserve active data streaks when stale empty-poll replies arrive after data starts flowing.
- Reduce idle refill pressure and keep upload overflow bounded.
- Change the default `block_stun` behavior to allow STUN/TURN unless explicitly blocked.
- Add Persian/English changelog entry and bump Android version metadata.

Local verification:

- `cargo test --lib`
- `cargo build --release`
- `cargo build --bin mhrv-rs-ui --release --features ui`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:assembleDebug`

---
Answered via LLM, Supervised @therealaleph
