### PR TITLE
release: prepare v1.9.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mhrv-rs"
-version = "1.9.31"
+version = "1.9.32"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mhrv-rs"
-version = "1.9.31"
+version = "1.9.32"
 edition = "2021"
 description = "Rust port of MasterHttpRelayVPN -- DPI bypass via Google Apps Script relay with domain fronting"
 license = "MIT"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.therealaleph.mhrv"
         minSdk = 24 // Android 7.0 — covers 99%+ of live devices.
         targetSdk = 34
-        versionCode = 163
-        versionName = "1.9.31"
+        versionCode = 164
+        versionName = "1.9.32"
 
         // Ship all four mainstream Android ABIs:
         //   - arm64-v8a      — 95%+ of real-world Android phones since 2019

--- a/docs/changelog/v1.9.32.md
+++ b/docs/changelog/v1.9.32.md
@@ -1,0 +1,11 @@
+• در حالت Full Tunnel، پروتکل batch حالا از فشرده سازی zstd پشتیبانی می کند. وقتی کلاینت جدید، `CodeFull.gs` جدید، و `tunnel-node` جدید همزمان استفاده شوند، درخواست ها و پاسخ های batch می توانند فشرده شوند و مصرف پهنای باند مخصوصا در دانلودهای سنگین کمتر شود.
+• فعال شدن فشرده سازی کاملا سازگار با نسخه های قدیمی است: اگر یکی از سه بخش هنوز آپدیت نشده باشد، سیستم به پاسخ های معمولی بدون فشرده سازی برمی گردد و نباید قطع شود.
+• برای استفاده از این قابلیت در Full mode، علاوه بر آپدیت برنامه، باید `CodeFull.gs` را دوباره به عنوان نسخه جدید deploy کنید و `tunnel-node` / Docker image روی VPS یا Cloud Run را هم redeploy کنید.
+• لاگ های batch فشرده شده دوباره امن تر شدند: بدنه پاسخ یا محتوای `zops` در سطح `info` چاپ نمی شود، و `TUNNEL_AUTH_KEY` قبل از باز کردن payload فشرده بررسی می شود.
+• با تشکر از @yyoyoian-pixel برای پیاده سازی و تست تجربی این قابلیت در PR #1314.
+---
+• Full Tunnel batch protocol now supports zstd compression. When the new client, new `CodeFull.gs`, and new `tunnel-node` are deployed together, batch requests and responses can be compressed, reducing bandwidth use especially on download-heavy traffic.
+• Compression negotiation is backward compatible: if any one of the three pieces is still old, the system falls back to normal uncompressed responses instead of failing.
+• To use this in Full mode, update the app, redeploy `CodeFull.gs` as a new Apps Script version, and redeploy `tunnel-node` / the Docker image on your VPS or Cloud Run.
+• Compressed batch logging is kept safer: response bodies and `zops` contents are not printed at `info`, and `TUNNEL_AUTH_KEY` is checked before opening compressed payloads.
+• Thanks to @yyoyoian-pixel for the implementation and empirical testing in PR #1314.

--- a/tunnel-node/Cargo.lock
+++ b/tunnel-node/Cargo.lock
@@ -443,7 +443,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mhrv-tunnel-node"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "base64",

--- a/tunnel-node/Cargo.toml
+++ b/tunnel-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mhrv-tunnel-node"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "HTTP tunnel bridge for MasterHttpRelayVPN full mode — bridges HTTP tunnel requests to real TCP connections"
 


### PR DESCRIPTION
## Summary
- Bump mhrv-rs to v1.9.32 and Android versionCode/versionName.
- Bump tunnel-node subcrate to 0.1.1 for the new compressed batch protocol surface.
- Add Persian/English changelog for Full Tunnel zstd compression from PR #1314.

## Local verification
- cargo test --lib
- cargo build --release
- cargo build --bin mhrv-rs-ui --release --features ui
- cargo test (tunnel-node)
- cargo build --release (tunnel-node)
- JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:assembleDebug

Docker local image build was attempted during PR verification, but Docker Desktop/daemon is not running on this Mac (`/Users/dev/.docker/run/docker.sock` missing). The release workflow tunnel-docker job will cover container publishing.

---
Answered via LLM, Supervised @therealaleph
