### PR TITLE
feat(proxy): consolidate local traffic policy controls

### DIFF
--- a/config.direct.example.toml
+++ b/config.direct.example.toml
@@ -8,6 +8,7 @@ listen_host = "127.0.0.1"
 listen_port = 8085
 socks5_port = 8086
 verify_ssl = true
+block_hosts = []
 
 [network.hosts]
 

--- a/config.direct.example.toml
+++ b/config.direct.example.toml
@@ -8,6 +8,8 @@ listen_host = "127.0.0.1"
 listen_port = 8085
 socks5_port = 8086
 verify_ssl = true
+# Local block-list rules answered before relay/tunnel dispatch.
+# Exact hostnames match only themselves; leading-dot entries also match subdomains.
 block_hosts = []
 
 [network.hosts]

--- a/config.example.toml
+++ b/config.example.toml
@@ -12,6 +12,9 @@ socks5_port = 8086
 verify_ssl = true
 # Suppress QUIC UDP/443 and DNS HTTPS/SVCB hints so browsers fall back to TCP.
 block_quic = true
+# Local block-list rules answered before relay/tunnel dispatch.
+# Exact hostnames match only themselves; leading-dot entries also match subdomains.
+block_hosts = []
 
 [network.hosts]
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,6 +10,8 @@ listen_host = "127.0.0.1"
 listen_port = 8085
 socks5_port = 8086
 verify_ssl = true
+# Suppress QUIC UDP/443 and DNS HTTPS/SVCB hints so browsers fall back to TCP.
+block_quic = true
 
 [network.hosts]
 

--- a/config.exit-node.example.toml
+++ b/config.exit-node.example.toml
@@ -13,6 +13,7 @@ listen_host = "0.0.0.0"
 listen_port = 8085
 socks5_port = 8086
 verify_ssl = true
+block_hosts = []
 
 [network.hosts]
 

--- a/config.full.example.toml
+++ b/config.full.example.toml
@@ -12,6 +12,9 @@ socks5_port = 8086
 verify_ssl = true
 # Suppress QUIC UDP/443 and DNS HTTPS/SVCB hints so browsers fall back to TCP.
 block_quic = true
+# Local block-list rules answered before relay/tunnel dispatch.
+# Exact hostnames match only themselves; leading-dot entries also match subdomains.
+block_hosts = []
 
 [network.hosts]
 

--- a/config.full.example.toml
+++ b/config.full.example.toml
@@ -10,6 +10,8 @@ listen_host = "127.0.0.1"
 listen_port = 8085
 socks5_port = 8086
 verify_ssl = true
+# Suppress QUIC UDP/443 and DNS HTTPS/SVCB hints so browsers fall back to TCP.
+block_quic = true
 
 [network.hosts]
 

--- a/docs/guide.fa.md
+++ b/docs/guide.fa.md
@@ -206,6 +206,17 @@ upstream_socks5 = "127.0.0.1:50529"
 
 HTTP / HTTPS مثل قبل از Apps Script می‌رود (تغییری نمی‌کند)، تونل بازنویسی SNI برای `google.com` / `youtube.com` همچنان از هر دو دور می‌زند — یوتیوب به سرعت قبل می‌ماند و تلگرام هم تونل واقعی پیدا می‌کند.
 
+## مسدودسازی محلی host
+
+برای مقصدهایی که نباید سهمیهٔ Apps Script، ظرفیت tunnel-node، یا ترافیک SOCKS5 upstream مصرف کنند، از `block_hosts` استفاده کن. entryهای دقیق فقط همان hostname را match می‌کنند؛ entryهایی که با `.` شروع می‌شوند هم parent suffix و هم subdomainها را match می‌کنند.
+
+```toml
+[network]
+block_hosts = ["ads.example.com", ".tracker.example"]
+```
+
+درخواست‌های HTTP و HTTP CONNECT مسدودشده پاسخ محلی `204 No Content` می‌گیرند. درخواست‌های SOCKS5 CONNECT قبل از باز شدن هر اتصال خروجی، reply خطای ruleset می‌گیرند.
+
 ## حالت تونل کامل
 
 `"mode": "full"` **تمام** ترافیک را end-to-end از Apps Script و یک [tunnel-node](../tunnel-node/) راه دور رد می‌کند — بدون نیاز به نصب گواهی MITM. TCP به‌صورت سشن‌های پایدار تونل، و UDP از کلاینت‌های اندروید / TUN از طریق SOCKS5 `UDP ASSOCIATE` به tunnel-node که UDP واقعی را از سمت سرور منتشر می‌کند. مبادله: تأخیر بیشتر هر درخواست (هر بایت Apps Script → tunnel-node → مقصد می‌رود)، اما برای هر پروتکل و هر برنامه‌ای بدون نصب CA کار می‌کند.
@@ -360,6 +371,7 @@ sni_hosts = ["www.google.com", "drive.google.com", "docs.google.com"]
 | ماسک Script ID | به‌صورت `prefix…suffix` در لاگ، تا Deployment ID افشا نشود |
 | UI دسکتاپ | egui — کراس‌پلتفرم، بدون bundler |
 | چِین SOCKS5 upstream | اختیاری برای ترافیک غیر-HTTP (MTProto تلگرام، IMAP، SSH …) |
+| مسدودسازی محلی `block_hosts` | short-circuit قبل از relay، tunnel، بازنویسی SNI، یا SOCKS5 upstream |
 | Pre-warm pool | اولین درخواست TLS handshake به لبهٔ گوگل را skip می‌کند |
 | چرخش SNI per-connection | بین `{www, mail, drive, docs, calendar}.google.com` |
 | Parallel relay | اختیاری: fan-out به N اسکریپت همزمان، اولین موفقیت برمی‌گردد |

--- a/docs/guide.fa.md
+++ b/docs/guide.fa.md
@@ -215,7 +215,9 @@ HTTP / HTTPS مثل قبل از Apps Script می‌رود (تغییری نمی�
 block_hosts = ["ads.example.com", ".tracker.example"]
 ```
 
-درخواست‌های HTTP و HTTP CONNECT مسدودشده پاسخ محلی `204 No Content` می‌گیرند. درخواست‌های SOCKS5 CONNECT قبل از باز شدن هر اتصال خروجی، reply خطای ruleset می‌گیرند.
+همین لیست از UI دسکتاپ هم قابل ویرایش است: **Advanced → Block hosts**. هر خط یک hostname است و هنگام Save دوباره در `network.block_hosts` ذخیره می‌شود؛ قوانین exact-match و suffix-match دقیقاً مثل تنظیم TOML باقی می‌ماند.
+
+درخواست‌های HTTP و HTTP CONNECT مسدودشده پاسخ محلی `204 No Content` می‌گیرند. درخواست‌های SOCKS5 CONNECT قبل از باز شدن هر اتصال خروجی، reply خطای ruleset می‌گیرند. پنل Traffic در UI دسکتاپ و خروجی JSON آمار، مقدار `blocked_requests` را نشان می‌دهند؛ یعنی تعداد hitهای block-list که قبل از relay، tunnel-node، بازنویسی SNI، یا SOCKS5 upstream متوقف شده‌اند.
 
 ## حالت تونل کامل
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -317,6 +317,8 @@ Memory footprint ~15–20 MB resident — fine on anything ≥128 MB RAM. No UI 
 - **`mhrv-rs test-sni`** — parallel TLS probe of every SNI name in your rotation pool against `google_ip`. Tells you which front-domain names pass through your ISP's DPI. UI has same thing in **SNI pool…** window with checkboxes, per-row **Test** buttons, and **Keep ✓ only** to auto-trim.
 - **Periodic stats** logged every 60 s at `info` level (relay calls, cache hit rate, bytes relayed, active vs blacklisted scripts). UI shows live.
 
+When `block_quic = true`, the SOCKS5 UDP relay drops UDP/443 datagrams and answers DNS HTTPS/SVCB (type 65/64) questions with an empty successful response. Browsers then skip HTTP/3 advertisement and fall back to TCP/HTTPS sooner, without forwarding those QUIC discovery packets through the relay.
+
 ### SNI pool editor
 
 By default, mhrv-rs rotates through `{www, mail, drive, docs, calendar}.google.com` on outbound TLS to your `google_ip`, to avoid fingerprinting one name too heavily. Some may be locally blocked (e.g. `mail.google.com` has been targeted in Iran at various times).

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -206,6 +206,17 @@ upstream_socks5 = "127.0.0.1:50529"
 
 HTTP / HTTPS keeps going through Apps Script (no change), and the SNI-rewrite tunnel for `google.com` / `youtube.com` keeps bypassing both — YouTube stays as fast as before while Telegram gets a real tunnel.
 
+## Local host blocking
+
+Use `block_hosts` for destinations that should be answered locally instead of spending Apps Script quota, tunnel-node capacity, or upstream SOCKS5 traffic. Exact entries match only that hostname; entries that start with `.` match the parent suffix and its subdomains.
+
+```toml
+[network]
+block_hosts = ["ads.example.com", ".tracker.example"]
+```
+
+Blocked HTTP and HTTP CONNECT requests receive a local `204 No Content` response. SOCKS5 CONNECT requests receive a ruleset failure reply before any outbound connection is opened.
+
 ## Full Tunnel mode
 
 `"mode": "full"` routes **all** traffic end-to-end through Apps Script and a remote [tunnel-node](../tunnel-node/) — no MITM certificate needed. TCP carried as persistent tunnel sessions, UDP from Android / TUN clients via SOCKS5 `UDP ASSOCIATE` to the tunnel-node which emits real UDP server-side. Trade-off: higher per-request latency (every byte goes Apps Script → tunnel-node → destination), but works for any protocol and any app, no CA install required.
@@ -358,6 +369,7 @@ This port focuses on the **`apps_script` mode** — the only one that reliably w
 - [x] Script IDs masked in logs (`prefix…suffix`) so logs don't leak deployment IDs
 - [x] Desktop UI (egui) — cross-platform, no bundler needed
 - [x] Optional upstream SOCKS5 chaining for non-HTTP traffic (Telegram MTProto, IMAP, SSH…)
+- [x] Local `block_hosts` short-circuit before relay, tunnel, SNI rewrite, or upstream SOCKS5 dispatch
 - [x] Connection pool pre-warm on startup
 - [x] Per-connection SNI rotation across `{www, mail, drive, docs, calendar}.google.com`
 - [x] Optional parallel script-ID dispatch (`parallel_relay`): fan-out to N script instances, return first success

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -215,7 +215,9 @@ Use `block_hosts` for destinations that should be answered locally instead of sp
 block_hosts = ["ads.example.com", ".tracker.example"]
 ```
 
-Blocked HTTP and HTTP CONNECT requests receive a local `204 No Content` response. SOCKS5 CONNECT requests receive a ruleset failure reply before any outbound connection is opened.
+You can edit the same list in the desktop UI under **Advanced → Block hosts**. The editor saves one hostname per line back to `network.block_hosts`, preserving the same exact-match and suffix-match behavior as the TOML field.
+
+Blocked HTTP and HTTP CONNECT requests receive a local `204 No Content` response. SOCKS5 CONNECT requests receive a ruleset failure reply before any outbound connection is opened. The desktop traffic panel and stats JSON expose `blocked_requests`, which counts local block-list hits that avoided relay, tunnel-node, SNI rewrite, and upstream SOCKS5 dispatch.
 
 ## Full Tunnel mode
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -317,7 +317,7 @@ Memory footprint ~15–20 MB resident — fine on anything ≥128 MB RAM. No UI 
 - **`mhrv-rs test-sni`** — parallel TLS probe of every SNI name in your rotation pool against `google_ip`. Tells you which front-domain names pass through your ISP's DPI. UI has same thing in **SNI pool…** window with checkboxes, per-row **Test** buttons, and **Keep ✓ only** to auto-trim.
 - **Periodic stats** logged every 60 s at `info` level (relay calls, cache hit rate, bytes relayed, active vs blacklisted scripts). UI shows live.
 
-When `block_quic = true`, the SOCKS5 UDP relay drops UDP/443 datagrams and answers DNS HTTPS/SVCB (type 65/64) questions with an empty successful response. Browsers then skip HTTP/3 advertisement and fall back to TCP/HTTPS sooner, without forwarding those QUIC discovery packets through the relay.
+When `block_quic = true`, the SOCKS5 UDP relay drops UDP/443 datagrams and answers DNS HTTPS/SVCB (type 65/64) questions with an empty successful response. Ordinary A/AAAA DNS questions are unchanged. Browsers then skip HTTP/3 advertisement and fall back to TCP/HTTPS sooner, without forwarding those QUIC discovery packets through the relay.
 
 ### SNI pool editor
 

--- a/src/bin/ui.rs
+++ b/src/bin/ui.rs
@@ -252,12 +252,11 @@ struct FormState {
     normalize_x_graphql: bool,
     youtube_via_relay: bool,
     passthrough_hosts: Vec<String>,
-    /// Config-only local block list. Round-tripped from config.toml so
-    /// UI Save preserves hand-edited quota-saving filters.
-    block_hosts: Vec<String>,
-    /// Round-tripped from config.toml so the UI's save path doesn't
-    /// drop the user's setting. Not currently exposed as a UI control;
-    /// users edit `block_quic` directly in `config.toml` (Issue #213).
+    /// Multiline editor buffer for local block-list entries. Saved back to
+    /// `network.block_hosts` after trimming blank lines.
+    block_hosts_text: String,
+    /// Exposed beside local host blocking so users can keep browser HTTP/3
+    /// probes from burning Full-mode UDP tunnel work.
     block_quic: bool,
     /// Round-tripped from config.toml and exposed beside QUIC blocking.
     /// Default true to push WebRTC apps toward TCP TURN instead of slow
@@ -382,7 +381,7 @@ fn load_form() -> (FormState, Option<String>) {
             normalize_x_graphql: c.normalize_x_graphql,
             youtube_via_relay: c.youtube_via_relay,
             passthrough_hosts: c.passthrough_hosts.clone(),
-            block_hosts: c.block_hosts.clone(),
+            block_hosts_text: format_host_list_for_editor(&c.block_hosts),
             block_quic: c.block_quic,
             block_stun: c.block_stun,
             disable_padding: c.disable_padding,
@@ -423,7 +422,7 @@ fn load_form() -> (FormState, Option<String>) {
             normalize_x_graphql: false,
             youtube_via_relay: false,
             passthrough_hosts: Vec::new(),
-            block_hosts: Vec::new(),
+            block_hosts_text: String::new(),
             block_quic: true,
             block_stun: false,
             disable_padding: false,
@@ -486,6 +485,19 @@ fn sni_pool_for_form(user: Option<&[String]>, front_domain: &str) -> Vec<SniRow>
         }
     }
     out
+}
+
+fn format_host_list_for_editor(hosts: &[String]) -> String {
+    hosts.join("\n")
+}
+
+fn parse_host_list_editor(input: &str) -> Vec<String> {
+    input
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty() && !s.starts_with('#'))
+        .map(str::to_string)
+        .collect()
 }
 
 impl FormState {
@@ -583,11 +595,7 @@ impl FormState {
             // Similarly config-only for now; round-trips through the
             // file so the UI doesn't drop the user's entries on save.
             passthrough_hosts: self.passthrough_hosts.clone(),
-            // Local block list: config-only, preserved on Save.
-            block_hosts: self.block_hosts.clone(),
-            // Issue #213: block_quic is config-only for now (no UI
-            // control yet). Round-trip through the file so save
-            // doesn't drop a user-set true.
+            block_hosts: parse_host_list_editor(&self.block_hosts_text),
             block_quic: self.block_quic,
             block_stun: self.block_stun,
             // Issue #391: disable_padding is config-only for now.
@@ -1116,6 +1124,39 @@ impl eframe::App for App {
                              Script relay instead — slower for video, but the visible SNI matches the site.",
                         );
                     });
+                    form_row(ui, "Block hosts", Some(
+                        "One hostname per line. Exact entries match only that host; entries \
+                         starting with a dot match the parent suffix and subdomains. Matching \
+                         requests are answered locally before relay, tunnel-node, SNI rewrite, \
+                         or upstream SOCKS5 dispatch, saving quota and latency."
+                    ), |ui, label_id| {
+                        ui.add(egui::TextEdit::multiline(&mut self.form.block_hosts_text)
+                            .hint_text("ads.example.com\n.tracker.example")
+                            .desired_width(f32::INFINITY)
+                            .desired_rows(3))
+                        .labelled_by(label_id);
+                    });
+                    let block_host_count = parse_host_list_editor(&self.form.block_hosts_text).len();
+                    ui.horizontal(|ui| {
+                        ui.add_space(120.0 + 8.0);
+                        let text = if block_host_count == 0 {
+                            "No local block rules configured.".to_string()
+                        } else {
+                            format!(
+                                "{} local block rule{} configured.",
+                                block_host_count,
+                                if block_host_count == 1 { "" } else { "s" }
+                            )
+                        };
+                        ui.small(
+                            egui::RichText::new(text)
+                                .color(if block_host_count == 0 {
+                                    egui::Color32::from_gray(140)
+                                } else {
+                                    OK_GREEN
+                                }),
+                        );
+                    });
                     ui.horizontal(|ui| {
                         ui.add_space(120.0 + 8.0);
                         ui.checkbox(&mut self.form.block_quic, "Block QUIC (UDP/443)")
@@ -1189,6 +1230,7 @@ impl eframe::App for App {
                         ("relay calls", s.relay_calls.to_string()),
                         ("failures", s.relay_failures.to_string()),
                         ("coalesced", s.coalesced.to_string()),
+                        ("blocked local", s.blocked_requests.to_string()),
                         (
                             "cache hits",
                             format!(
@@ -2578,5 +2620,36 @@ fn push_log(shared: &Shared, msg: &str) {
     s.log.push_back(line);
     while s.log.len() > LOG_MAX {
         s.log.pop_front();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_host_list_for_editor, parse_host_list_editor};
+
+    #[test]
+    fn host_list_editor_trims_blank_and_comment_lines() {
+        let parsed = parse_host_list_editor(
+            "\n  ads.example.com  \n# saved note\n.tracker.example\n   \n",
+        );
+        assert_eq!(
+            parsed,
+            vec![
+                "ads.example.com".to_string(),
+                ".tracker.example".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn host_list_editor_round_trips_one_host_per_line() {
+        let hosts = vec![
+            "ads.example.com".to_string(),
+            ".tracker.example".to_string(),
+        ];
+        assert_eq!(
+            parse_host_list_editor(&format_host_list_for_editor(&hosts)),
+            hosts
+        );
     }
 }

--- a/src/bin/ui.rs
+++ b/src/bin/ui.rs
@@ -1193,6 +1193,11 @@ impl eframe::App for App {
                         ),
                         ("cache size", format!("{} KB", s.cache_bytes / 1024)),
                         ("bytes relayed", fmt_bytes(s.bytes_relayed)),
+                        ("QUIC drops", s.policy_quic_udp_drops.to_string()),
+                        (
+                            "HTTPS RR",
+                            s.policy_https_rr_suppressed.to_string(),
+                        ),
                         (
                             "active scripts",
                             format!(

--- a/src/bin/ui.rs
+++ b/src/bin/ui.rs
@@ -252,6 +252,9 @@ struct FormState {
     normalize_x_graphql: bool,
     youtube_via_relay: bool,
     passthrough_hosts: Vec<String>,
+    /// Config-only local block list. Round-tripped from config.toml so
+    /// UI Save preserves hand-edited quota-saving filters.
+    block_hosts: Vec<String>,
     /// Round-tripped from config.toml so the UI's save path doesn't
     /// drop the user's setting. Not currently exposed as a UI control;
     /// users edit `block_quic` directly in `config.toml` (Issue #213).
@@ -379,6 +382,7 @@ fn load_form() -> (FormState, Option<String>) {
             normalize_x_graphql: c.normalize_x_graphql,
             youtube_via_relay: c.youtube_via_relay,
             passthrough_hosts: c.passthrough_hosts.clone(),
+            block_hosts: c.block_hosts.clone(),
             block_quic: c.block_quic,
             block_stun: c.block_stun,
             disable_padding: c.disable_padding,
@@ -419,6 +423,7 @@ fn load_form() -> (FormState, Option<String>) {
             normalize_x_graphql: false,
             youtube_via_relay: false,
             passthrough_hosts: Vec::new(),
+            block_hosts: Vec::new(),
             block_quic: true,
             block_stun: false,
             disable_padding: false,
@@ -578,6 +583,8 @@ impl FormState {
             // Similarly config-only for now; round-trips through the
             // file so the UI doesn't drop the user's entries on save.
             passthrough_hosts: self.passthrough_hosts.clone(),
+            // Local block list: config-only, preserved on Save.
+            block_hosts: self.block_hosts.clone(),
             // Issue #213: block_quic is config-only for now (no UI
             // control yet). Round-trip through the file so save
             // doesn't drop a user-set true.

--- a/src/config.rs
+++ b/src/config.rs
@@ -180,6 +180,17 @@ pub struct Config {
     #[serde(default)]
     pub passthrough_hosts: Vec<String>,
 
+    /// Local block list evaluated before any relay, SNI rewrite, upstream
+    /// SOCKS5, or Full Tunnel dispatch. Matching follows the same convention
+    /// as `passthrough_hosts`: exact hostnames match only themselves, and
+    /// leading-dot entries match the bare suffix plus subdomains.
+    ///
+    /// This is intentionally local-only. It saves Apps Script quota and
+    /// tunnel latency for hosts the user does not want to contact at all,
+    /// without changing the remote Apps Script or tunnel-node data planes.
+    #[serde(default)]
+    pub block_hosts: Vec<String>,
+
     /// Block outbound QUIC (UDP/443) at the SOCKS5 listener.
     ///
     /// QUIC is HTTP/3-over-UDP. In `apps_script` mode it's hopeless —
@@ -793,6 +804,8 @@ pub struct TomlNetwork {
     pub sni_hosts: Option<Vec<String>>,
     #[serde(default)]
     pub passthrough_hosts: Vec<String>,
+    #[serde(default)]
+    pub block_hosts: Vec<String>,
     #[serde(default = "default_tunnel_doh")]
     pub tunnel_doh: bool,
     #[serde(default = "default_block_doh")]
@@ -817,6 +830,7 @@ impl Default for TomlNetwork {
             block_stun: default_block_stun(),
             sni_hosts: None,
             passthrough_hosts: Vec::new(),
+            block_hosts: Vec::new(),
             tunnel_doh: default_tunnel_doh(),
             block_doh: default_block_doh(),
             bypass_doh_hosts: Vec::new(),
@@ -907,6 +921,7 @@ impl From<TomlConfig> for Config {
             normalize_x_graphql: t.relay.normalize_x_graphql,
             youtube_via_relay: t.relay.youtube_via_relay,
             passthrough_hosts: t.network.passthrough_hosts,
+            block_hosts: t.network.block_hosts,
             block_stun: t.network.block_stun,
             block_quic: t.network.block_quic,
             disable_padding: t.relay.disable_padding,
@@ -959,6 +974,7 @@ impl From<&Config> for TomlConfig {
                 block_stun: c.block_stun,
                 sni_hosts: c.sni_hosts.clone(),
                 passthrough_hosts: c.passthrough_hosts.clone(),
+                block_hosts: c.block_hosts.clone(),
                 tunnel_doh: c.tunnel_doh,
                 block_doh: c.block_doh,
                 bypass_doh_hosts: c.bypass_doh_hosts.clone(),
@@ -1389,6 +1405,29 @@ mode = "direct"
     }
 
     #[test]
+    fn toml_parses_block_hosts_and_roundtrips_through_config() {
+        let s = r#"
+[relay]
+mode = "direct"
+
+[network]
+block_hosts = ["ads.example.com", ".tracker.example"]
+"#;
+        let toml_cfg: TomlConfig = toml::from_str(s).unwrap();
+        let cfg = Config::from(toml_cfg);
+        assert_eq!(
+            cfg.block_hosts,
+            vec!["ads.example.com".to_string(), ".tracker.example".to_string()]
+        );
+
+        let toml_again = TomlConfig::from(&cfg);
+        assert_eq!(
+            toml_again.network.block_hosts,
+            vec!["ads.example.com".to_string(), ".tracker.example".to_string()]
+        );
+    }
+
+    #[test]
     fn toml_multi_script_id_array() {
         let s = r#"
 [relay]
@@ -1423,7 +1462,8 @@ script_id = "ABCDEF"
   "mode": "apps_script",
   "auth_key": "MY_SECRET_KEY_123",
   "script_id": "ABCDEF",
-  "listen_port": 8085
+  "listen_port": 8085,
+  "block_hosts": ["ads.example.com", ".tracker.example"]
 }"#;
         let dir = std::env::temp_dir();
         let json_path = dir.join("mhrv-migration-test.json");
@@ -1446,6 +1486,11 @@ script_id = "ABCDEF"
         assert_eq!(cfg.auth_key, cfg2.auth_key);
         assert_eq!(cfg.script_ids_resolved(), cfg2.script_ids_resolved());
         assert_eq!(cfg.listen_port, cfg2.listen_port);
+        assert_eq!(cfg.block_hosts, cfg2.block_hosts);
+        assert_eq!(
+            cfg2.block_hosts,
+            vec!["ads.example.com".to_string(), ".tracker.example".to_string()]
+        );
 
         let _ = std::fs::remove_file(&json_path);
         let _ = std::fs::remove_file(&toml_path);

--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -367,6 +367,11 @@ pub struct DomainFronter {
     relay_calls: AtomicU64,
     relay_failures: AtomicU64,
     bytes_relayed: AtomicU64,
+    /// Requests rejected locally by the proxy `block_hosts` gate before any
+    /// Apps Script, tunnel-node, SNI rewrite, or upstream SOCKS5 dispatch.
+    /// Shared with `ProxyServer` so the short-circuit path can account for
+    /// quota savings where the decision actually happens.
+    blocked_requests: Arc<AtomicU64>,
     /// Relay calls that successfully completed over the h2 fast path,
     /// across **all** entry points: Apps-Script direct relays,
     /// exit-node outer calls, full-mode tunnel single ops, and
@@ -626,6 +631,7 @@ impl DomainFronter {
             relay_calls: AtomicU64::new(0),
             relay_failures: AtomicU64::new(0),
             bytes_relayed: AtomicU64::new(0),
+            blocked_requests: Arc::new(AtomicU64::new(0)),
             h2_calls: AtomicU64::new(0),
             h2_fallbacks: AtomicU64::new(0),
             policy_quic_udp_drops: AtomicU64::new(0),
@@ -770,6 +776,7 @@ impl DomainFronter {
             relay_failures: self.relay_failures.load(Ordering::Relaxed),
             coalesced: self.coalesced.load(Ordering::Relaxed),
             bytes_relayed: self.bytes_relayed.load(Ordering::Relaxed),
+            blocked_requests: self.blocked_requests.load(Ordering::Relaxed),
             cache_hits: self.cache.hits(),
             cache_misses: self.cache.misses(),
             cache_bytes: self.cache.size(),
@@ -808,6 +815,10 @@ impl DomainFronter {
 
     pub fn cache(&self) -> &ResponseCache {
         &self.cache
+    }
+
+    pub(crate) fn blocked_requests_counter(&self) -> Arc<AtomicU64> {
+        self.blocked_requests.clone()
     }
 
     pub fn coalesced_count(&self) -> u64 {
@@ -4813,6 +4824,9 @@ pub struct StatsSnapshot {
     pub relay_failures: u64,
     pub coalesced: u64,
     pub bytes_relayed: u64,
+    /// Local block-list hits rejected before a relay, tunnel-node, SNI
+    /// rewrite, or upstream SOCKS5 connection is opened.
+    pub blocked_requests: u64,
     pub cache_hits: u64,
     pub cache_misses: u64,
     pub cache_bytes: usize,
@@ -4886,11 +4900,12 @@ impl StatsSnapshot {
             }
         };
         format!(
-            "stats: relay={} ({}KB) failures={} coalesced={} cache={}/{} ({:.0}% hit, {}KB) scripts={}/{} active{} policy=quic-drops:{} https-rr:{}",
+            "stats: relay={} ({}KB) failures={} coalesced={} blocked={} cache={}/{} ({:.0}% hit, {}KB) scripts={}/{} active{} policy=quic-drops:{} https-rr:{}",
             self.relay_calls,
             self.bytes_relayed / 1024,
             self.relay_failures,
             self.coalesced,
+            self.blocked_requests,
             self.cache_hits,
             self.cache_hits + self.cache_misses,
             self.hit_rate(),
@@ -4912,11 +4927,12 @@ impl StatsSnapshot {
             s.replace('\\', "\\\\").replace('"', "\\\"")
         }
         format!(
-            r#"{{"relay_calls":{},"relay_failures":{},"coalesced":{},"bytes_relayed":{},"cache_hits":{},"cache_misses":{},"cache_bytes":{},"blacklisted_scripts":{},"total_scripts":{},"today_calls":{},"today_bytes":{},"today_key":"{}","today_reset_secs":{},"h2_calls":{},"h2_fallbacks":{},"h2_disabled":{},"policy_quic_udp_drops":{},"policy_https_rr_suppressed":{}}}"#,
+            r#"{{"relay_calls":{},"relay_failures":{},"coalesced":{},"bytes_relayed":{},"blocked_requests":{},"cache_hits":{},"cache_misses":{},"cache_bytes":{},"blacklisted_scripts":{},"total_scripts":{},"today_calls":{},"today_bytes":{},"today_key":"{}","today_reset_secs":{},"h2_calls":{},"h2_fallbacks":{},"h2_disabled":{},"policy_quic_udp_drops":{},"policy_https_rr_suppressed":{}}}"#,
             self.relay_calls,
             self.relay_failures,
             self.coalesced,
             self.bytes_relayed,
+            self.blocked_requests,
             self.cache_hits,
             self.cache_misses,
             self.cache_bytes,
@@ -5103,6 +5119,36 @@ mod tests {
             self.position += take;
             Poll::Ready(Ok(()))
         }
+    }
+
+    #[test]
+    fn stats_snapshot_exports_local_block_counter() {
+        let snapshot = StatsSnapshot {
+            relay_calls: 10,
+            relay_failures: 1,
+            coalesced: 2,
+            bytes_relayed: 4096,
+            blocked_requests: 7,
+            cache_hits: 3,
+            cache_misses: 4,
+            cache_bytes: 2048,
+            blacklisted_scripts: 0,
+            total_scripts: 2,
+            today_calls: 5,
+            today_bytes: 1024,
+            today_key: "2026-05-24".to_string(),
+            today_reset_secs: 3600,
+            h2_calls: 8,
+            h2_fallbacks: 2,
+            h2_disabled: false,
+            policy_quic_udp_drops: 11,
+            policy_https_rr_suppressed: 13,
+        };
+
+        assert!(snapshot.fmt_line().contains("blocked=7"));
+        assert!(snapshot.to_json().contains(r#""blocked_requests":7"#));
+        assert!(snapshot.fmt_line().contains("quic-drops:11"));
+        assert!(snapshot.to_json().contains(r#""policy_https_rr_suppressed":13"#));
     }
 
     #[tokio::test]

--- a/src/domain_fronter.rs
+++ b/src/domain_fronter.rs
@@ -390,6 +390,8 @@ pub struct DomainFronter {
     /// h2_fallbacks)` ratio indicates an unhealthy h2 conn or a flaky
     /// middlebox eating h2 frames; consider `force_http1: true`.
     h2_fallbacks: AtomicU64,
+    policy_quic_udp_drops: AtomicU64,
+    policy_https_rr_suppressed: AtomicU64,
     /// Per-host breakdown of traffic going through this fronter. Keyed by
     /// the host of the URL (e.g. "api.x.com"). Read-mostly; only touched
     /// on the slow path (once per relayed request), so a plain Mutex is
@@ -626,6 +628,8 @@ impl DomainFronter {
             bytes_relayed: AtomicU64::new(0),
             h2_calls: AtomicU64::new(0),
             h2_fallbacks: AtomicU64::new(0),
+            policy_quic_udp_drops: AtomicU64::new(0),
+            policy_https_rr_suppressed: AtomicU64::new(0),
             per_site: Arc::new(std::sync::Mutex::new(HashMap::new())),
             today_calls: AtomicU64::new(0),
             today_bytes: AtomicU64::new(0),
@@ -778,7 +782,20 @@ impl DomainFronter {
             h2_calls: self.h2_calls.load(Ordering::Relaxed),
             h2_fallbacks: self.h2_fallbacks.load(Ordering::Relaxed),
             h2_disabled: self.h2_disabled.load(Ordering::Relaxed),
+            policy_quic_udp_drops: self.policy_quic_udp_drops.load(Ordering::Relaxed),
+            policy_https_rr_suppressed: self
+                .policy_https_rr_suppressed
+                .load(Ordering::Relaxed),
         }
+    }
+
+    pub fn record_quic_udp_drop(&self) {
+        self.policy_quic_udp_drops.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_https_rr_suppressed(&self) {
+        self.policy_https_rr_suppressed
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn num_scripts(&self) -> usize {
@@ -4831,6 +4848,11 @@ pub struct StatsSnapshot {
     /// switch set, or peer refused h2 during ALPN). All traffic on the
     /// h1 path.
     pub h2_disabled: bool,
+    /// UDP/443 datagrams dropped locally while `block_quic` is enabled.
+    pub policy_quic_udp_drops: u64,
+    /// DNS SVCB/HTTPS questions answered locally with an empty response
+    /// while `block_quic` is enabled.
+    pub policy_https_rr_suppressed: u64,
 }
 
 impl StatsSnapshot {
@@ -4864,7 +4886,7 @@ impl StatsSnapshot {
             }
         };
         format!(
-            "stats: relay={} ({}KB) failures={} coalesced={} cache={}/{} ({:.0}% hit, {}KB) scripts={}/{} active{}",
+            "stats: relay={} ({}KB) failures={} coalesced={} cache={}/{} ({:.0}% hit, {}KB) scripts={}/{} active{} policy=quic-drops:{} https-rr:{}",
             self.relay_calls,
             self.bytes_relayed / 1024,
             self.relay_failures,
@@ -4876,6 +4898,8 @@ impl StatsSnapshot {
             self.total_scripts - self.blacklisted_scripts,
             self.total_scripts,
             h2_seg,
+            self.policy_quic_udp_drops,
+            self.policy_https_rr_suppressed,
         )
     }
 
@@ -4888,7 +4912,7 @@ impl StatsSnapshot {
             s.replace('\\', "\\\\").replace('"', "\\\"")
         }
         format!(
-            r#"{{"relay_calls":{},"relay_failures":{},"coalesced":{},"bytes_relayed":{},"cache_hits":{},"cache_misses":{},"cache_bytes":{},"blacklisted_scripts":{},"total_scripts":{},"today_calls":{},"today_bytes":{},"today_key":"{}","today_reset_secs":{},"h2_calls":{},"h2_fallbacks":{},"h2_disabled":{}}}"#,
+            r#"{{"relay_calls":{},"relay_failures":{},"coalesced":{},"bytes_relayed":{},"cache_hits":{},"cache_misses":{},"cache_bytes":{},"blacklisted_scripts":{},"total_scripts":{},"today_calls":{},"today_bytes":{},"today_key":"{}","today_reset_secs":{},"h2_calls":{},"h2_fallbacks":{},"h2_disabled":{},"policy_quic_udp_drops":{},"policy_https_rr_suppressed":{}}}"#,
             self.relay_calls,
             self.relay_failures,
             self.coalesced,
@@ -4905,6 +4929,8 @@ impl StatsSnapshot {
             self.h2_calls,
             self.h2_fallbacks,
             self.h2_disabled,
+            self.policy_quic_udp_drops,
+            self.policy_https_rr_suppressed,
         )
     }
 }

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -3600,6 +3600,13 @@ mod tests {
         q
     }
 
+    fn dns_query_with_class(qtype: u16, qclass: u16) -> Vec<u8> {
+        let mut q = dns_query(qtype);
+        let n = q.len();
+        q[n - 2..n].copy_from_slice(&qclass.to_be_bytes());
+        q
+    }
+
     #[test]
     fn dns_https_question_gets_empty_success_response() {
         let query = dns_query(DNS_TYPE_HTTPS);
@@ -3610,6 +3617,20 @@ mod tests {
         assert_eq!(&response[4..6], &[0x00, 0x01]);
         assert_eq!(&response[6..12], &[0, 0, 0, 0, 0, 0]);
         assert_eq!(&response[12..], &query[12..]);
+    }
+
+    #[test]
+    fn dns_https_response_preserves_rd_and_clears_additional_records() {
+        let mut query = dns_query(DNS_TYPE_HTTPS);
+        // Pretend the client included one additional record after the
+        // question. The local policy answer must not echo that section.
+        query[11] = 1;
+        query.extend_from_slice(&[0, 0, 41, 16, 0, 0, 0, 0, 0, 0, 0]);
+
+        let response = dns_empty_response_for_https_or_svcb(&query).unwrap();
+        assert_eq!(response[2] & 0x01, 0x01);
+        assert_eq!(&response[10..12], &[0, 0]);
+        assert!(response.len() < query.len());
     }
 
     #[test]
@@ -3628,6 +3649,24 @@ mod tests {
     fn dns_multi_question_query_is_not_suppressed() {
         let mut query = dns_query(DNS_TYPE_HTTPS);
         query[5] = 2;
+        assert!(dns_empty_response_for_https_or_svcb(&query).is_none());
+    }
+
+    #[test]
+    fn dns_compressed_question_name_is_not_suppressed() {
+        let mut query = Vec::new();
+        query.extend_from_slice(&[0x12, 0x34, 0x01, 0x00]);
+        query.extend_from_slice(&[0x00, 0x01, 0x00, 0x00]);
+        query.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        query.extend_from_slice(&[0xc0, 0x0c]);
+        query.extend_from_slice(&DNS_TYPE_HTTPS.to_be_bytes());
+        query.extend_from_slice(&1u16.to_be_bytes());
+        assert!(dns_empty_response_for_https_or_svcb(&query).is_none());
+    }
+
+    #[test]
+    fn dns_non_in_question_is_not_suppressed() {
+        let query = dns_query_with_class(DNS_TYPE_HTTPS, 3);
         assert!(dns_empty_response_for_https_or_svcb(&query).is_none());
     }
 

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -1,9 +1,11 @@
 use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
+use portable_atomic::AtomicU64;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::sync::{mpsc, Mutex};
@@ -241,6 +243,7 @@ pub struct RewriteCtx {
     /// consuming relay, tunnel, SNI-rewrite, or upstream SOCKS5 resources.
     /// Matching follows `passthrough_hosts` semantics.
     pub block_hosts: Vec<String>,
+    pub blocked_requests: Arc<AtomicU64>,
     /// If true, drop SOCKS5 UDP datagrams destined for port 443 so
     /// callers fall back to TCP/HTTPS. See config.rs `block_quic` for
     /// the trade-off. Issue #213.
@@ -412,6 +415,12 @@ pub fn matches_block_host(host: &str, list: &[String]) -> bool {
     matches_passthrough(host, list)
 }
 
+fn record_blocked_request(rewrite_ctx: &RewriteCtx) {
+    rewrite_ctx
+        .blocked_requests
+        .fetch_add(1, Ordering::Relaxed);
+}
+
 impl ProxyServer {
     pub fn new(config: &Config, mitm: Arc<Mutex<MitmCertManager>>) -> Result<Self, ProxyError> {
         let mode = config
@@ -516,6 +525,10 @@ impl ProxyServer {
             youtube_via_relay: config.youtube_via_relay,
             passthrough_hosts: config.passthrough_hosts.clone(),
             block_hosts: config.block_hosts.clone(),
+            blocked_requests: fronter
+                .as_ref()
+                .map(|f| f.blocked_requests_counter())
+                .unwrap_or_else(|| Arc::new(AtomicU64::new(0))),
             block_quic: config.block_quic,
             block_stun: config.block_stun,
             bypass_doh: !config.tunnel_doh,
@@ -825,6 +838,7 @@ async fn handle_http_client(
     if method.eq_ignore_ascii_case("CONNECT") {
         let (host, port) = parse_host_port(&target);
         if matches_block_host(&host, &rewrite_ctx.block_hosts) {
+            record_blocked_request(&rewrite_ctx);
             tracing::info!("CONNECT {}:{} blocked locally by block_hosts", host, port);
             write_http_no_content(&mut sock).await?;
             return Ok(());
@@ -850,6 +864,7 @@ async fn handle_http_client(
     } else {
         if let Some((host, port, _path)) = resolve_plain_http_target(&target, &headers) {
             if matches_block_host(&host, &rewrite_ctx.block_hosts) {
+                record_blocked_request(&rewrite_ctx);
                 tracing::info!("HTTP {}:{} blocked locally by block_hosts", host, port);
                 write_http_no_content(&mut sock).await?;
                 return Ok(());
@@ -949,6 +964,7 @@ async fn handle_socks5_client(
     }
 
     if matches_block_host(&host, &rewrite_ctx.block_hosts) {
+        record_blocked_request(&rewrite_ctx);
         tracing::info!("SOCKS5 CONNECT -> {}:{} blocked locally by block_hosts", host, port);
         sock.write_all(&[0x05, 0x02, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
             .await?;
@@ -1238,6 +1254,7 @@ async fn handle_socks5_udp_associate(
                 }
 
                 if matches_block_host(&target.host, &rewrite_ctx.block_hosts) {
+                    record_blocked_request(&rewrite_ctx);
                     tracing::debug!("udp dropped: target {} blocked by block_hosts", target.host);
                     continue;
                 }
@@ -1756,6 +1773,7 @@ async fn dispatch_tunnel(
     tunnel_mux: Option<Arc<TunnelMux>>,
 ) -> std::io::Result<()> {
     if matches_block_host(&host, &rewrite_ctx.block_hosts) {
+        record_blocked_request(&rewrite_ctx);
         tracing::info!("dispatch {}:{} -> blocked locally by block_hosts", host, port);
         drop(sock);
         return Ok(());

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -237,6 +237,10 @@ pub struct RewriteCtx {
     /// and pass through as plain TCP (optionally via upstream_socks5).
     /// See config.rs `passthrough_hosts` for matching rules. Issues #39, #127.
     pub passthrough_hosts: Vec<String>,
+    /// User-configured hostnames that should be answered locally instead of
+    /// consuming relay, tunnel, SNI-rewrite, or upstream SOCKS5 resources.
+    /// Matching follows `passthrough_hosts` semantics.
+    pub block_hosts: Vec<String>,
     /// If true, drop SOCKS5 UDP datagrams destined for port 443 so
     /// callers fall back to TCP/HTTPS. See config.rs `block_quic` for
     /// the trade-off. Issue #213.
@@ -404,6 +408,10 @@ pub fn matches_passthrough(host: &str, list: &[String]) -> bool {
     })
 }
 
+pub fn matches_block_host(host: &str, list: &[String]) -> bool {
+    matches_passthrough(host, list)
+}
+
 impl ProxyServer {
     pub fn new(config: &Config, mitm: Arc<Mutex<MitmCertManager>>) -> Result<Self, ProxyError> {
         let mode = config
@@ -507,6 +515,7 @@ impl ProxyServer {
             mode,
             youtube_via_relay: config.youtube_via_relay,
             passthrough_hosts: config.passthrough_hosts.clone(),
+            block_hosts: config.block_hosts.clone(),
             block_quic: config.block_quic,
             block_stun: config.block_stun,
             bypass_doh: !config.tunnel_doh,
@@ -810,11 +819,16 @@ async fn handle_http_client(
         }
     };
 
-    let (method, target, _version, _headers) = parse_request_head(&head)
+    let (method, target, _version, headers) = parse_request_head(&head)
         .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "bad request"))?;
 
     if method.eq_ignore_ascii_case("CONNECT") {
         let (host, port) = parse_host_port(&target);
+        if matches_block_host(&host, &rewrite_ctx.block_hosts) {
+            tracing::info!("CONNECT {}:{} blocked locally by block_hosts", host, port);
+            write_http_no_content(&mut sock).await?;
+            return Ok(());
+        }
         // Mirror the SOCKS5 short-circuit: if the tunnel-node just failed
         // this (host, port) with unreachable, return 502 immediately rather
         // than acknowledging the CONNECT and blowing tunnel quota on a
@@ -834,6 +848,13 @@ async fn handle_http_client(
         sock.flush().await?;
         dispatch_tunnel(sock, host, port, fronter, mitm, rewrite_ctx, tunnel_mux).await
     } else {
+        if let Some((host, port, _path)) = resolve_plain_http_target(&target, &headers) {
+            if matches_block_host(&host, &rewrite_ctx.block_hosts) {
+                tracing::info!("HTTP {}:{} blocked locally by block_hosts", host, port);
+                write_http_no_content(&mut sock).await?;
+                return Ok(());
+            }
+        }
         // Plain HTTP proxy request (e.g. `GET http://…`).
         //
         // apps_script mode: relay through the Apps Script fronter (which
@@ -925,6 +946,14 @@ async fn handle_socks5_client(
     if cmd == 0x03 {
         tracing::info!("SOCKS5 UDP ASSOCIATE requested for {}:{}", host, port);
         return handle_socks5_udp_associate(sock, fronter, rewrite_ctx, tunnel_mux).await;
+    }
+
+    if matches_block_host(&host, &rewrite_ctx.block_hosts) {
+        tracing::info!("SOCKS5 CONNECT -> {}:{} blocked locally by block_hosts", host, port);
+        sock.write_all(&[0x05, 0x02, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+            .await?;
+        sock.flush().await?;
+        return Ok(());
     }
 
     // Negative-cache short-circuit: if the tunnel-node just failed to reach
@@ -1206,6 +1235,11 @@ async fn handle_socks5_udp_associate(
                         }
                         continue;
                     }
+                }
+
+                if matches_block_host(&target.host, &rewrite_ctx.block_hosts) {
+                    tracing::debug!("udp dropped: target {} blocked by block_hosts", target.host);
+                    continue;
                 }
 
                 // Issue #213: client-side QUIC block. UDP/443 is
@@ -1525,6 +1559,16 @@ async fn write_socks5_reply(
     sock.flush().await
 }
 
+async fn write_http_no_content(sock: &mut TcpStream) -> std::io::Result<()> {
+    sock.write_all(
+        b"HTTP/1.1 204 No Content\r\n\
+          Connection: close\r\n\
+          Content-Length: 0\r\n\r\n",
+    )
+    .await?;
+    sock.flush().await
+}
+
 /// Parse the SOCKS5 UDP frame header and return the target plus the byte
 /// offset at which the payload starts. Splitting "structure parsing"
 /// from "give me a payload slice" lets the recv hot path stay on a
@@ -1711,6 +1755,12 @@ async fn dispatch_tunnel(
     rewrite_ctx: Arc<RewriteCtx>,
     tunnel_mux: Option<Arc<TunnelMux>>,
 ) -> std::io::Result<()> {
+    if matches_block_host(&host, &rewrite_ctx.block_hosts) {
+        tracing::info!("dispatch {}:{} -> blocked locally by block_hosts", host, port);
+        drop(sock);
+        return Ok(());
+    }
+
     // 0. User-configured passthrough list wins over every other path.
     //    If the host matches `passthrough_hosts`, we raw-TCP it (through
     //    upstream_socks5 if set) and never touch Apps Script, SNI-rewrite,
@@ -3668,6 +3718,21 @@ mod tests {
     fn dns_non_in_question_is_not_suppressed() {
         let query = dns_query_with_class(DNS_TYPE_HTTPS, 3);
         assert!(dns_empty_response_for_https_or_svcb(&query).is_none());
+    }
+
+    #[test]
+    fn block_hosts_use_passthrough_matching_rules() {
+        let list = vec![
+            "ads.example.com".to_string(),
+            ".tracker.example".to_string(),
+            "  ".to_string(),
+        ];
+        assert!(matches_block_host("ads.example.com", &list));
+        assert!(matches_block_host("ADS.EXAMPLE.COM.", &list));
+        assert!(!matches_block_host("cdn.ads.example.com", &list));
+        assert!(matches_block_host("tracker.example", &list));
+        assert!(matches_block_host("pixel.tracker.example", &list));
+        assert!(!matches_block_host("nottracker.example", &list));
     }
 
     #[test]

--- a/src/proxy_server.rs
+++ b/src/proxy_server.rs
@@ -924,7 +924,7 @@ async fn handle_socks5_client(
 
     if cmd == 0x03 {
         tracing::info!("SOCKS5 UDP ASSOCIATE requested for {}:{}", host, port);
-        return handle_socks5_udp_associate(sock, rewrite_ctx, tunnel_mux).await;
+        return handle_socks5_udp_associate(sock, fronter, rewrite_ctx, tunnel_mux).await;
     }
 
     // Negative-cache short-circuit: if the tunnel-node just failed to reach
@@ -1095,6 +1095,7 @@ const MAX_UDP_PAYLOAD_BYTES: usize = 9 * 1024;
 
 async fn handle_socks5_udp_associate(
     mut control: TcpStream,
+    fronter: Option<Arc<DomainFronter>>,
     rewrite_ctx: Arc<RewriteCtx>,
     tunnel_mux: Option<Arc<TunnelMux>>,
 ) -> std::io::Result<()> {
@@ -1190,6 +1191,23 @@ async fn handle_socks5_udp_associate(
                 };
                 let payload_slice = &recv_buf[payload_off..n];
 
+                if rewrite_ctx.block_quic && target.port == 53 {
+                    if let Some(response) = dns_empty_response_for_https_or_svcb(payload_slice) {
+                        if let Some(f) = &fronter {
+                            f.record_https_rr_suppressed();
+                        }
+                        let framed = build_socks5_udp_packet(&target, &response);
+                        if let Err(e) = udp.send_to(&framed, peer).await {
+                            tracing::debug!(
+                                "udp DNS HTTPS/SVCB suppression reply to {} failed: {}",
+                                peer,
+                                e
+                            );
+                        }
+                        continue;
+                    }
+                }
+
                 // Issue #213: client-side QUIC block. UDP/443 is
                 // HTTP/3 — drop the datagram silently so the client
                 // stack retries a couple of times and then falls back
@@ -1207,6 +1225,9 @@ async fn handle_socks5_udp_associate(
                 // a "no response → fall back" timeout, so silent drop
                 // is the contractually correct shape.
                 if rewrite_ctx.block_quic && target.port == 443 {
+                    if let Some(f) = &fronter {
+                        f.record_quic_udp_drop();
+                    }
                     tracing::debug!(
                         "udp dropped: block_quic=true, target {}:443",
                         target.host
@@ -1594,6 +1615,69 @@ fn build_socks5_udp_packet(target: &SocksUdpTarget, payload: &[u8]) -> Vec<u8> {
     out.extend_from_slice(&target.port.to_be_bytes());
     out.extend_from_slice(payload);
     out
+}
+
+const DNS_TYPE_SVCB: u16 = 64;
+const DNS_TYPE_HTTPS: u16 = 65;
+
+fn dns_empty_response_for_https_or_svcb(query: &[u8]) -> Option<Vec<u8>> {
+    let question_end = dns_single_question_https_or_svcb_end(query)?;
+    let mut out = Vec::with_capacity(question_end);
+    out.extend_from_slice(&query[..question_end]);
+    // QR=1, opcode copied, AA=0, TC=0, RD copied, RA=0, Z=0, RCODE=0.
+    out[2] = (query[2] & 0x78) | 0x80 | (query[2] & 0x01);
+    out[3] = 0x00;
+    // QDCOUNT stays 1. ANCOUNT, NSCOUNT, ARCOUNT become 0.
+    out[6] = 0;
+    out[7] = 0;
+    out[8] = 0;
+    out[9] = 0;
+    out[10] = 0;
+    out[11] = 0;
+    Some(out)
+}
+
+fn dns_single_question_https_or_svcb_end(query: &[u8]) -> Option<usize> {
+    if query.len() < 12 {
+        return None;
+    }
+    let qdcount = u16::from_be_bytes([query[4], query[5]]);
+    if qdcount != 1 {
+        return None;
+    }
+    if query[2] & 0x80 != 0 {
+        return None;
+    }
+
+    let mut pos = 12usize;
+    loop {
+        let len = *query.get(pos)?;
+        pos += 1;
+        if len == 0 {
+            break;
+        }
+        if len & 0xc0 != 0 {
+            return None;
+        }
+        let label_len = len as usize;
+        if label_len > 63 || pos.checked_add(label_len)? > query.len() {
+            return None;
+        }
+        pos += label_len;
+    }
+    if pos.checked_add(4)? > query.len() {
+        return None;
+    }
+    let qtype = u16::from_be_bytes([query[pos], query[pos + 1]]);
+    let qclass = u16::from_be_bytes([query[pos + 2], query[pos + 3]]);
+    if qclass != 1 {
+        return None;
+    }
+    if qtype == DNS_TYPE_SVCB || qtype == DNS_TYPE_HTTPS {
+        Some(pos + 4)
+    } else {
+        None
+    }
 }
 
 // ---------- Smart dispatch (used by both HTTP CONNECT and SOCKS5) ----------
@@ -3499,6 +3583,52 @@ mod tests {
         let list = vec!["example.com.".to_string()];
         assert!(matches_passthrough("example.com", &list));
         assert!(matches_passthrough("example.com.", &list));
+    }
+
+    fn dns_query(qtype: u16) -> Vec<u8> {
+        let mut q = Vec::new();
+        q.extend_from_slice(&[0x12, 0x34, 0x01, 0x00]);
+        q.extend_from_slice(&[0x00, 0x01, 0x00, 0x00]);
+        q.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        for label in ["www", "example", "com"] {
+            q.push(label.len() as u8);
+            q.extend_from_slice(label.as_bytes());
+        }
+        q.push(0);
+        q.extend_from_slice(&qtype.to_be_bytes());
+        q.extend_from_slice(&1u16.to_be_bytes());
+        q
+    }
+
+    #[test]
+    fn dns_https_question_gets_empty_success_response() {
+        let query = dns_query(DNS_TYPE_HTTPS);
+        let response = dns_empty_response_for_https_or_svcb(&query).unwrap();
+        assert_eq!(&response[0..2], &[0x12, 0x34]);
+        assert_eq!(response[2] & 0x80, 0x80);
+        assert_eq!(response[3] & 0x0f, 0);
+        assert_eq!(&response[4..6], &[0x00, 0x01]);
+        assert_eq!(&response[6..12], &[0, 0, 0, 0, 0, 0]);
+        assert_eq!(&response[12..], &query[12..]);
+    }
+
+    #[test]
+    fn dns_svcb_question_gets_empty_success_response() {
+        let query = dns_query(DNS_TYPE_SVCB);
+        assert!(dns_empty_response_for_https_or_svcb(&query).is_some());
+    }
+
+    #[test]
+    fn dns_a_question_is_not_suppressed() {
+        let query = dns_query(1);
+        assert!(dns_empty_response_for_https_or_svcb(&query).is_none());
+    }
+
+    #[test]
+    fn dns_multi_question_query_is_not_suppressed() {
+        let mut query = dns_query(DNS_TYPE_HTTPS);
+        query[5] = 2;
+        assert!(dns_empty_response_for_https_or_svcb(&query).is_none());
     }
 
     #[test]


### PR DESCRIPTION
This consolidates local traffic-policy behavior into one reviewable proxy slice.

When `block_quic = true`, SOCKS5 UDP DNS requests for HTTPS/SVCB records are answered locally with an empty successful response. Ordinary A/AAAA DNS traffic is left untouched. This lets browsers skip advertised HTTP/3 endpoints earlier instead of discovering them through DNS and then spending time on UDP/443 retries that will be blocked by policy.

The branch also adds a local `block_hosts` policy evaluated before relay, tunnel-node, SNI rewrite, or upstream SOCKS5 dispatch. Matching HTTP and CONNECT traffic is answered locally, SOCKS5 CONNECT receives a ruleset failure reply, and matching UDP traffic is dropped locally. Matching follows the existing host-list convention: exact entries match only that hostname, and leading-dot entries match the parent suffix plus subdomains.

The desktop UI now exposes a multiline Block hosts editor, preserves the TOML value on save, and shows local policy counters in the stats panel. Stats JSON includes both local block-list hits and QUIC policy counters so Android/UI consumers can surface the same behavior without parsing logs.

Validation:
- `git diff --check`
- `cargo test dns_ --lib`
- `cargo test block_hosts --lib`
- `cargo test stats_snapshot_exports_local_block_counter --lib`
- `cargo test host_list_editor --features ui --bin mhrv-rs-ui`